### PR TITLE
Fix error in match script

### DIFF
--- a/match/scott_pd.py
+++ b/match/scott_pd.py
@@ -1,5 +1,6 @@
 from datamatch import ColumnsIndex, JaroWinklerSimilarity, ThresholdMatcher
 from lib.path import data_file_path, ensure_data_dir
+from lib.post import extract_events_from_post
 import pandas as pd
 import sys
 sys.path.append('../')
@@ -33,7 +34,7 @@ def match_cprr(cprr, pprr):
     return cprr
 
 
-def match_pprr_and_post(pprr, post):
+def extract_post_events(pprr, post):
     dfa = pprr[['uid', 'first_name', 'last_name']]
     dfa.loc[:, 'fc'] = dfa.first_name.map(lambda x: x[:1])
     dfa = dfa.drop_duplicates(subset=['uid']).set_index('uid')
@@ -48,47 +49,18 @@ def match_pprr_and_post(pprr, post):
     }, dfa, dfb)
     decision = 1
     matcher.save_pairs_to_excel(data_file_path(
-        'match/scott_pd_pprr_2021_v_post_pprr_2020_11_06.xlsx'), decision)
+        "match/scott_pd_pprr_2021_v_post_pprr_2020_11_06.xlsx"), decision)
     matches = matcher.get_index_pairs_within_thresholds(lower_bound=decision)
-    match_dict = dict(matches)
 
-    pprr.loc[:, 'uid'] = pprr.uid.map(lambda x: match_dict.get(x, x))
-    return pprr
-
-
-def match_cprr_and_post(cprr, post):
-    dfa = cprr[['uid', 'first_name', 'last_name']]
-    dfa.loc[:, 'fc'] = dfa.first_name.map(lambda x: x[:1])
-    dfa = dfa.drop_duplicates(subset=['uid']).set_index('uid')
-
-    dfb = post[['uid', 'first_name', 'last_name']]
-    dfb.loc[:, 'fc'] = dfb.first_name.map(lambda x: x[:1])
-    dfb = dfb.drop_duplicates(subset=['uid']).set_index('uid')
-
-    matcher = ThresholdMatcher(ColumnsIndex(['fc']), {
-        'last_name': JaroWinklerSimilarity(),
-        'first_name': JaroWinklerSimilarity(),
-    }, dfa, dfb)
-    decision = 1
-    matcher.save_pairs_to_excel(data_file_path(
-        'match/scott_pd_cprr_2020_v_post_pprr_2020_11_06.xlsx'), decision)
-    matches = matcher.get_index_pairs_within_thresholds(lower_bound=decision)
-    match_dict = dict(matches)
-
-    cprr.loc[:, 'uid'] = cprr.uid.map(lambda x: match_dict.get(x, x))
-    return cprr
+    return extract_events_from_post(post, matches, "Scott PD")
 
 
 if __name__ == '__main__':
-    cprr = pd.read_csv(data_file_path(
-        'clean/cprr_scott_pd_2020.csv'))
+    cprr = pd.read_csv(data_file_path('clean/cprr_scott_pd_2020.csv'))
     pprr = pd.read_csv(data_file_path('clean/pprr_scott_pd_2021.csv'))
     post = prepare_post_data()
     cprr = match_cprr(cprr, pprr)
-    post_event = pd.concat([
-        match_pprr_and_post(pprr, post),
-        match_cprr_and_post(cprr, post)
-    ]).drop_duplicates(ignore_index=True)
+    post_event = extract_post_events(pprr, post)
     ensure_data_dir('match')
     cprr.to_csv(data_file_path(
         'match/cprr_scott_pd_2020.csv'), index=False)


### PR DESCRIPTION
@ayyubibrahimi sorry for not spotting the problems in the original pull request but 2 things:
- Please make sure that `make` run without error before committing.
- I see that the original problem was with the `match/scott_pd.py` script. I looked at your script and essentially what you were doing are:
    1. Assign `pprr.uid` to `cprr.uid`. This is okay.
    2. Assign `post.uid` to `pprr.uid`. I don't know why you do this, maybe I did this in a script in the past but surely most scripts should no longer be doing this. Why would we need the `uid` from POST when we already have the roster data? We only take `uid` from POST if the roster data is not available and so we have to lift the roster from POST. 
    3. Assign `post.uid` to `cprr.uid`. Again, not needed because we already have roster data.
    4. Combine `pprr` and `cprr` into `post_event` which I think you did because you didn't understand what `post_event` is. `post_event` are `OFFICER_LEVEL_1_CERT` and `OFFICER_PC_12_QUALIFICATION` events extracted from POST for a particular agency. Because matching is needed to extract these events from POST, this `post_event` data is often produced in matching scripts instead of fusing scripts. Please look at `lib.post.extract_events_from_post`.

I think you are already doing the clean step well, just some hiccups in the match step. Please keep up the good work!