### PR TITLE
Add EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# 4 space indentation
+[*.py]
+indent_style = space
+indent_size = 4
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["editorconfig.editorconfig"]
+}


### PR DESCRIPTION
@ayyubibrahimi  the diff is not working properly probably because VSCode on Windows use another character for newline. After you approve this PR please install [this extension](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) so that all newlines follow Unix standard from now on.