### PR TITLE
Bugs/misc

### DIFF
--- a/clean/baton_rouge_da_cprr_2021.py
+++ b/clean/baton_rouge_da_cprr_2021.py
@@ -1,19 +1,37 @@
 from lib.columns import clean_column_names
 from lib.path import data_file_path
-from lib.clean import clean_names
+from lib.clean import clean_names, standardize_desc_cols
 from lib.uid import gen_uid
 import pandas as pd
 import sys
 sys.path.append("../")
 
 
+def clean_allegations(df):
+    df.loc[:, 'allegation'] = df.rule_violaton.str.lower().str.strip()\
+        .str.replace('sustained ', '', regex=False)\
+        .str.replace('arrested and/or convicted of a ', '', regex=False)
+    return df
+
+
+def extract_disposition(df):
+    df.loc[:, 'disposition'] = df.rule_violaton.str.lower().str.strip()\
+        .str.replace(' finding of untruthfulness', '', regex=False)\
+        .str.replace(' of a criminal violation', '', regex=False)
+    return df.drop(columns='rule_violaton')
+
+
 def clean():
     df = pd.read_csv(data_file_path(
-        "raw/baton_rouge_da/baton_rouge_da_cprr_2021.csv"))
-    df = clean_column_names(df)
+        "raw/baton_rouge_da/baton_rouge_da_cprr_2021.csv"))\
+        .pipe(clean_column_names)\
+        .pipe(clean_allegations)\
+        .pipe(extract_disposition)
     return df\
         .pipe(clean_names, ['first_name', 'last_name', 'middle_name'])\
-        .pipe(gen_uid, ['agency', 'first_name', 'last_name', 'middle_name'])
+        .pipe(standardize_desc_cols, ['status'])\
+        .pipe(gen_uid, ['agency', 'first_name', 'last_name', 'middle_name'])\
+        .pipe(gen_uid, ['uid', 'allegation', 'disposition'], 'allegation_uid')
 
 
 if __name__ == '__main__':

--- a/clean/bossier_city_pd_cprr.py
+++ b/clean/bossier_city_pd_cprr.py
@@ -129,8 +129,8 @@ def split_rows_with_multiple_officers_and_split_names(df):
     return df.drop(columns=['officer', 'other_officers'])
 
 
-def clean_summary(df):
-    df.loc[:, 'summary'] = df.synopsis.str.lower().str.strip()\
+def clean_allegation_desc(df):
+    df.loc[:, 'allegation_desc'] = df.synopsis.str.lower().str.strip()\
         .str.replace('bcpd', 'bossier city police department', regex=False)\
         .str.replace(r'all[ae]g[ae][sn]', 'alleges', regex=True)\
         .str.replace('sicla', 'stole', regex=False).str.replace(r'[oa]ffic[ae]rs\b', 'officers', regex=True)\
@@ -203,7 +203,7 @@ def clean():
         .pipe(extract_and_clean_disposition)\
         .pipe(clean_actions)\
         .pipe(clean_investigating_supervisor)\
-        .pipe(clean_summary)\
+        .pipe(clean_allegation_desc)\
         .pipe(assign_dispositions)\
         .pipe(assign_action)\
         .pipe(assign_agency)\

--- a/clean/lafayette_pd.py
+++ b/clean/lafayette_pd.py
@@ -752,14 +752,15 @@ def clean_cprr_14():
         })\
         .pipe(gen_uid, ['first_name', 'last_name', 'agency'])\
         .pipe(gen_uid, ['agency', 'investigator_first_name', 'investigator_last_name'], 'investigator_uid')\
-        .pipe(gen_uid, ['uid', 'charges', 'action', 'tracking_number', 'disposition'], 'complaint_uid')
+        .pipe(gen_uid, ['uid', 'charges', 'action', 'tracking_number', 'disposition'], 'allegation_uid')
     return df
 
 
 if __name__ == '__main__':
     pprr = clean_pprr()
-    cprr = clean_cprr()
-    cprr.to_csv(data_file_path(
+    cprr_20 = clean_cprr_20()
+    cprr_14 = clean_cprr_14()
+    cprr_20.to_csv(data_file_path(
         'clean/cprr_lafayette_pd_2015_2020.csv'
     ), index=False)
     cprr_14.to_csv(data_file_path(

--- a/clean/st_tammany_so_cprr.py
+++ b/clean/st_tammany_so_cprr.py
@@ -9,7 +9,7 @@ sys.path.append('../')
 
 def remove_newlines(df):
     for col in ['full_name', 'occur_raw_date', 'allegation']:
-        df.loc[:, col] = df[col].str.replace(r'(\d)\r\n(\d)', r'\1\2')\
+        df.loc[:, col] = df[col].str.replace(r'(\d)\r\n(\d)', r'\1\2', regex=True)\
             .str.replace(r'\r\n', ' ')
     return df
 
@@ -25,7 +25,7 @@ def assign_department_desc(df):
         "raw/st_tammany_so/st_tammany_department_codes_tabula.csv"
     ))
     dept_df = clean_column_names(dept_df)
-    dept_df.loc[:, 'loc'] = dept_df.loc[:, 'loc'].str.replace(r'\*$', '')
+    dept_df.loc[:, 'loc'] = dept_df.loc[:, 'loc'].str.replace(r'\*$', '', regex=True)
     dept_df = dept_df.set_index('loc')
     dept_dict = dept_df.org_code.to_dict()
     dept_dict["20"] = "St. Tammany Parish Jail"
@@ -57,7 +57,7 @@ def gen_middle_initial(df):
 
 
 def remove_new_lines_from_allegations(df):
-    df.loc[:, 'allegation'] = df.allegation.str.replace(r'(\n|\r)\s*', ' ')
+    df.loc[:, 'allegation'] = df.allegation.str.replace(r'(\n|\r)\s*', ' ', regex=True)
     return df
 
 

--- a/clean/tangipahoa_so_cprr.py
+++ b/clean/tangipahoa_so_cprr.py
@@ -40,14 +40,14 @@ def split_full_name(df):
 
 
 def clean_dept_desc(df):
-    df.dept_desc = df.dept_desc.str.lower().str.strip()\
+    df.loc[:, 'department_desc'] = df.dept_desc.str.lower().str.strip()\
         .str.replace('sro', 'school resource department', regex=False)\
         .str.replace(r'^res$', 'reserve', regex=True)\
         .str.replace('cid', 'criminal investigations division', regex=False)\
         .str.replace(r'pat(?:roll?)?', r'patrol', regex=True)\
         .str.replace('comm', 'communications', regex=False)\
         .str.replace('admin', 'administration', regex=False)
-    return df.fillna('')
+    return df.fillna('').drop(columns='dept_desc')
 
 
 def clean_complaint_type(df):

--- a/clean/terrebonne_so_cprr.py
+++ b/clean/terrebonne_so_cprr.py
@@ -17,7 +17,7 @@ def clean():
     df = pd.read_csv(data_file_path('raw/terrebonne_so/terrebonne_so_cprr_2019_2021_byhand.csv'))\
         .rename(columns={
             'diposition_date': 'disposition_date',
-            'initial_action': 'action',
+            'final_action': 'action',
             'investigation_end_date': 'investigation_complete_date'
         })\
         .pipe(clean_allegation)\
@@ -27,7 +27,7 @@ def clean():
             'agency': 'Terrebonne Parish SO'
         })\
         .pipe(gen_uid, ['agency', 'first_name', 'last_name'])\
-        .pipe(gen_uid, ['uid', 'allegation', 'disposition', 'action', 'final_action'], 'allegation_uid')
+        .pipe(gen_uid, ['uid', 'allegation', 'disposition', 'initial_action', 'action'], 'allegation_uid')
     return df
 
 

--- a/data/datavalid.yml
+++ b/data/datavalid.yml
@@ -127,10 +127,10 @@ schemas:
           - mixed
       - name: action
         description: >
-          what (disciplinary) actions were taken regarding this complaint
-      - name: final_action
+          what final (disciplinary) actions were taken regarding this complaint
+      - name: initial_action
         description: >
-          what action was taken after the appeal process
+          what initial disciplinary action was taken regarding this complaint
       - name: agency
         description: >
           the police department the accused belong to.

--- a/data/datavalid.yml
+++ b/data/datavalid.yml
@@ -85,6 +85,9 @@ schemas:
       - name: citizen
         description: >
           demographic info of the involved citizen
+      - name: initial_disposition
+        description: >
+          the initial disposition for the complaint
       - name: disposition
         description: >
           the final disposition for the complaint

--- a/fuse/lafayette_pd.py
+++ b/fuse/lafayette_pd.py
@@ -27,6 +27,16 @@ def fuse_events(cprr_20, cprr_14, pprr):
             'keep': ['agency', 'allegation_uid', 'uid', 'invetigator_uid'],
         },
     }, ['allegation_uid'])
+    builder.extract_events(cprr_14, {
+        events.COMPLAINT_RECEIVE: {
+            'prefix': 'receive',
+            'keep': ['agency', 'allegation_uid', 'uid', 'invetigator_uid']
+        },
+        events.INVESTIGATION_COMPLETE: {
+            'prefix': 'complete',
+            'keep': ['agency', 'allegation_uid', 'uid', 'invetigator_uid'],
+        },
+    }, ['allegation_uid'])
     builder.extract_events(pprr, {
         events.OFFICER_HIRE: {
             'prefix': 'hire',
@@ -75,7 +85,7 @@ if __name__ == '__main__':
             'investigator_last_name': 'last_name',
         })
     )
-    com = rearrange_allegation_columns(cprr)
+    com = rearrange_allegation_columns(pd.concat([cprr_20, cprr_14]))
     per.to_csv(data_file_path(
         'fuse/per_lafayette_pd.csv'
     ), index=False)


### PR DESCRIPTION
- renamed `summary` to `allegation_desc` for various departments
- fixed regex patterns to remove error message for various departments
- fixed bugs in cprr_lafayette_pd_2009_2014
- additional cleaning of baton_rouge_da_cprr_2021
- renamed `directive` column to `allegation_desc ` for cprr_new_orleans_da; and introduced an initial_disposition column to data_valid
- removed `charge_uid` in favor of `allegation_uid` for cprr_port_allen
- renamed `dept_desc `to `department_desc`
- split rows with multiple allegations in cprr_new_orleans_so
- In datavalid: reframed `action` to be defined as `final_action` and introduced `initial_action` as a column