### PR TITLE
Add TimedAccessor

### DIFF
--- a/lib/pandas_extensions.py
+++ b/lib/pandas_extensions.py
@@ -1,0 +1,40 @@
+import time
+
+import pandas as pd
+
+
+@pd.api.extensions.register_dataframe_accessor("timed")
+class TimedAccessor:
+    """Times Pandas pipe method.
+
+    Call this accessor's pipe method (df.timed.pipe) instead of regular pipe method
+    in order to time function execution and print duration.
+
+    Examples:
+        # just import this module for this accessor to become available
+        import lib.pandas_extensions
+
+        ...
+
+        # time my_func and print duration
+        df.timed.pipe(my_func, *args, **kwargs)
+    """
+
+    _obj: pd.DataFrame
+
+    def __init__(self, pandas_obj):
+        self._obj = pandas_obj
+
+    def pipe(self, func, *args, **kwargs):
+        def timed_func(df, *args, **kwargs):
+            start = time.perf_counter()
+            result = func(df, *args, **kwargs)
+            print(
+                "timed.pipe(%s) (%.2fs)" % (func.__name__, time.perf_counter() - start)
+            )
+            return result
+
+        return self._obj.pipe(timed_func, *args, **kwargs)
+
+    def __getattr__(self, item):
+        return getattr(self._obj, item)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ requests==2.26.0
 wrgl==0.7.3.1
 flake8==4.0.1
 black==21.12b0
-deba==0.0.5
+deba==0.0.6


### PR DESCRIPTION
1. Added `lib.pandas_extensions.TimedAccessor`. This accessor allow you to time piped function execution:

```python
# just import this module for this accessor to become available
import lib.pandas_extensions

...

# replace df.pipe with df.timed.pipe will time my_func and print duration
df.timed.pipe(my_func, *args, **kwargs)
```

2. Upgrade `deba` to v0.0.6 which allow using `deba` outside of the root folder. For example inside a notebook:

```python
# deba.yaml is in the parent folder
import deba; deba.set_root('..')

...

# call deba.data like normal
df = pd.read_csv(deba.data('my_data.csv'))
```