### PR TITLE
Unravel raw.dvc to one file per subfolder

### DIFF
--- a/.github/workflows/process_data.yml
+++ b/.github/workflows/process_data.yml
@@ -26,7 +26,7 @@ jobs:
         run: sudo bash -c 'curl -L https://github.com/wrgl/wrgl/releases/latest/download/install.sh | bash'
       - name: dvc pull
         run: |
-          sed -iE 's/wdir\: data/wdir\: \/runner\/_work\/data\/data/g' raw.dvc
+          find dvc/data/raw -type f | xargs -I{} sed -iE 's/wdir\: ..\/..\/..\/data\/raw/wdir\: \/runner\/_work\/data\/data\/raw/g' {}
           mkdir /runner/_work/data/dvc_cache || true
           dvc cache dir --local /runner/_work/data/dvc_cache
           dvc pull

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ data.d
 !.wrgl/config.yaml
 
 data
+!dvc/data
 build
 .env
 .deba
+
+*.log

--- a/dvc/data/raw/abbeville_pd.dvc
+++ b/dvc/data/raw/abbeville_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: f44e5ecd449ddae643c6a5920a681f88.dir
+  size: 3231
+  nfiles: 2
+  path: abbeville_pd

--- a/dvc/data/raw/acadia_so.dvc
+++ b/dvc/data/raw/acadia_so.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 5e2913249edeb28f37647d358e757ffa.dir
+  size: 3158
+  nfiles: 1
+  path: acadia_so

--- a/dvc/data/raw/ascension_so.dvc
+++ b/dvc/data/raw/ascension_so.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 5373c240383fbf235afa7ce353337088.dir
+  size: 5821
+  nfiles: 2
+  path: ascension_so

--- a/dvc/data/raw/baker_pd.dvc
+++ b/dvc/data/raw/baker_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 50256a0059595867250fd90706d294c8.dir
+  size: 9842
+  nfiles: 3
+  path: baker_pd

--- a/dvc/data/raw/baton_rouge_csd.dvc
+++ b/dvc/data/raw/baton_rouge_csd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 1980702e22218ca17e555f31b2bdd973.dir
+  size: 2504562
+  nfiles: 2
+  path: baton_rouge_csd

--- a/dvc/data/raw/baton_rouge_da.dvc
+++ b/dvc/data/raw/baton_rouge_da.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: fff2467543aa790075d39ba22ca7a2fe.dir
+  size: 4163
+  nfiles: 1
+  path: baton_rouge_da

--- a/dvc/data/raw/baton_rouge_fpcsb.dvc
+++ b/dvc/data/raw/baton_rouge_fpcsb.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 8e2f6072101263fea79ca4dccfa0e463.dir
+  size: 32164
+  nfiles: 1
+  path: baton_rouge_fpcsb

--- a/dvc/data/raw/baton_rouge_pd.dvc
+++ b/dvc/data/raw/baton_rouge_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 385cdcdb5c75b8a2eab92172a82f345b.dir
+  size: 259476
+  nfiles: 3
+  path: baton_rouge_pd

--- a/dvc/data/raw/baton_rouge_so.dvc
+++ b/dvc/data/raw/baton_rouge_so.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 68be927dedbab180e6e09c48a88a645b.dir
+  size: 1139681
+  nfiles: 3
+  path: baton_rouge_so

--- a/dvc/data/raw/benton_pd.dvc
+++ b/dvc/data/raw/benton_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 7fd2b4c5fec808ffea119c881440c134.dir
+  size: 5961
+  nfiles: 2
+  path: benton_pd

--- a/dvc/data/raw/bossier_city_pd.dvc
+++ b/dvc/data/raw/bossier_city_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 2678c16ebd2228657427b7a5ca2f1239.dir
+  size: 114605
+  nfiles: 3
+  path: bossier_city_pd

--- a/dvc/data/raw/brusly_pd.dvc
+++ b/dvc/data/raw/brusly_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 5e00c4e2a1983fdd6e360a60c3011968.dir
+  size: 3560
+  nfiles: 3
+  path: brusly_pd

--- a/dvc/data/raw/caddo_parish_so.dvc
+++ b/dvc/data/raw/caddo_parish_so.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 2713198aa622699dd7d288914765ff76.dir
+  size: 138948
+  nfiles: 1
+  path: caddo_parish_so

--- a/dvc/data/raw/cameron_so.dvc
+++ b/dvc/data/raw/cameron_so.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 92bb6010f1cd0bb322343cb27d8b3b99.dir
+  size: 158063
+  nfiles: 5
+  path: cameron_so

--- a/dvc/data/raw/carencro_pd.dvc
+++ b/dvc/data/raw/carencro_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 21df67b1046cca31d6be7af269dab9a7.dir
+  size: 1274
+  nfiles: 1
+  path: carencro_pd

--- a/dvc/data/raw/central_csd.dvc
+++ b/dvc/data/raw/central_csd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 9772e53b604b0ee837bfccdd799cde59.dir
+  size: 4791
+  nfiles: 1
+  path: central_csd

--- a/dvc/data/raw/covington_pd.dvc
+++ b/dvc/data/raw/covington_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 99c460c4174765e63d4cd1664952321e.dir
+  size: 57961
+  nfiles: 13
+  path: covington_pd

--- a/dvc/data/raw/cross_agency.dvc
+++ b/dvc/data/raw/cross_agency.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: bc4b4535e0d2d7d1165aa9e20af5616b.dir
+  size: 41021
+  nfiles: 1
+  path: cross_agency

--- a/dvc/data/raw/denham_springs_pd.dvc
+++ b/dvc/data/raw/denham_springs_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: c8ec391760e0fb47abe1635591e8c3dc.dir
+  size: 4618
+  nfiles: 1
+  path: denham_springs_pd

--- a/dvc/data/raw/district_attorney.dvc
+++ b/dvc/data/raw/district_attorney.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: a6417cadb05ac016a8237d9ac1457811.dir
+  size: 4054622
+  nfiles: 1
+  path: district_attorney

--- a/dvc/data/raw/erath_pd.dvc
+++ b/dvc/data/raw/erath_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 4e7c53e255f8c0e13797175d7a90ccd4.dir
+  size: 451
+  nfiles: 1
+  path: erath_pd

--- a/dvc/data/raw/eunice_pd.dvc
+++ b/dvc/data/raw/eunice_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 110684c89df6c2684ddf03ab38e136d5.dir
+  size: 754
+  nfiles: 1
+  path: eunice_pd

--- a/dvc/data/raw/fused.dvc
+++ b/dvc/data/raw/fused.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: e8e1e77623d909fa608b21494d5296db.dir
+  size: 183132862
+  nfiles: 2
+  path: fused

--- a/dvc/data/raw/gonzales_pd.dvc
+++ b/dvc/data/raw/gonzales_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 60ce90d36602c251265b7782d9488ab5.dir
+  size: 5578
+  nfiles: 1
+  path: gonzales_pd

--- a/dvc/data/raw/grand_isle.dvc
+++ b/dvc/data/raw/grand_isle.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 0ac4442a7010adb2d53c12f19e9165e6.dir
+  size: 1189
+  nfiles: 1
+  path: grand_isle

--- a/dvc/data/raw/greenwood_pd.dvc
+++ b/dvc/data/raw/greenwood_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 638c4bb05b18fb3d068ca35c8fc9f211.dir
+  size: 477
+  nfiles: 1
+  path: greenwood_pd

--- a/dvc/data/raw/gretna_pd.dvc
+++ b/dvc/data/raw/gretna_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 15bb045fc547134bb1477ea4766300e0.dir
+  size: 6156
+  nfiles: 1
+  path: gretna_pd

--- a/dvc/data/raw/hammond_pd.dvc
+++ b/dvc/data/raw/hammond_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 6439360171b67bcc0b6a518936bbe0f3.dir
+  size: 28576
+  nfiles: 4
+  path: hammond_pd

--- a/dvc/data/raw/harahan_csd.dvc
+++ b/dvc/data/raw/harahan_csd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 9bc943364744cbc04d0552d4a8a4277a.dir
+  size: 16283
+  nfiles: 2
+  path: harahan_csd

--- a/dvc/data/raw/harahan_pd.dvc
+++ b/dvc/data/raw/harahan_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 5c6cd909f66e8f825942423e541df8ea.dir
+  size: 667
+  nfiles: 1
+  path: harahan_pd

--- a/dvc/data/raw/houma_pd.dvc
+++ b/dvc/data/raw/houma_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 74a90e856c807ca7582b0deaa8038005.dir
+  size: 17052
+  nfiles: 2
+  path: houma_pd

--- a/dvc/data/raw/ipm.dvc
+++ b/dvc/data/raw/ipm.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: abdda8ea670357e23bd208918d4845b6.dir
+  size: 282479128
+  nfiles: 11
+  path: ipm

--- a/dvc/data/raw/jefferson_so.dvc
+++ b/dvc/data/raw/jefferson_so.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 0fb5dcf437024b948bf8d1fe1599a38c.dir
+  size: 78680
+  nfiles: 1
+  path: jefferson_so

--- a/dvc/data/raw/kenner_pd.dvc
+++ b/dvc/data/raw/kenner_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 7ffb0c544700aa10ce53fbe1123039dc.dir
+  size: 82449
+  nfiles: 4
+  path: kenner_pd

--- a/dvc/data/raw/lafayette_pd.dvc
+++ b/dvc/data/raw/lafayette_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 7dc59729151e516744e4970b29fc5166.dir
+  size: 114427
+  nfiles: 3
+  path: lafayette_pd

--- a/dvc/data/raw/lafayette_so.dvc
+++ b/dvc/data/raw/lafayette_so.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 5e532b7537606f5b885d22df2e75a852.dir
+  size: 70188
+  nfiles: 6
+  path: lafayette_so

--- a/dvc/data/raw/lafourche_so.dvc
+++ b/dvc/data/raw/lafourche_so.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 4ec5160409dc177581dcd8b24e0301d0.dir
+  size: 24482
+  nfiles: 4
+  path: lafourche_so

--- a/dvc/data/raw/lake_charles_pd.dvc
+++ b/dvc/data/raw/lake_charles_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 7fd2e7a31a7d4b3fa71c3f8c614e45d7.dir
+  size: 33439
+  nfiles: 3
+  path: lake_charles_pd

--- a/dvc/data/raw/levee_pd.dvc
+++ b/dvc/data/raw/levee_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: f6ba6b08c50d7de32b685561b6f8b0ca.dir
+  size: 6138
+  nfiles: 2
+  path: levee_pd

--- a/dvc/data/raw/louisiana_csd.dvc
+++ b/dvc/data/raw/louisiana_csd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 4f3be4710c388d983e956f547e28ef63.dir
+  size: 2181051
+  nfiles: 2
+  path: louisiana_csd

--- a/dvc/data/raw/louisiana_state_csc.dvc
+++ b/dvc/data/raw/louisiana_state_csc.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 1c8c375e22bd1ca0c0da6df2ba79db99.dir
+  size: 16549
+  nfiles: 2
+  path: louisiana_state_csc

--- a/dvc/data/raw/madisonville_pd.dvc
+++ b/dvc/data/raw/madisonville_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 41264944774ff72aeecf5f3b1193f3dd.dir
+  size: 2457
+  nfiles: 3
+  path: madisonville_pd

--- a/dvc/data/raw/mandeville_pd.dvc
+++ b/dvc/data/raw/mandeville_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 8a9af67a63aa74716caf973fbd40d0da.dir
+  size: 6032
+  nfiles: 2
+  path: mandeville_pd

--- a/dvc/data/raw/maurice_pd.dvc
+++ b/dvc/data/raw/maurice_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: a3db73842fede111d1366e8e317c1aba.dir
+  size: 677
+  nfiles: 1
+  path: maurice_pd

--- a/dvc/data/raw/new_orleans_csc.dvc
+++ b/dvc/data/raw/new_orleans_csc.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 01edb7e1bb09f399b6015e244445cd19.dir
+  size: 110936
+  nfiles: 1
+  path: new_orleans_csc

--- a/dvc/data/raw/new_orleans_csd.dvc
+++ b/dvc/data/raw/new_orleans_csd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: d5b493ffbd313c2c0626fb33cfb4c7ff.dir
+  size: 624461
+  nfiles: 2
+  path: new_orleans_csd

--- a/dvc/data/raw/new_orleans_da.dvc
+++ b/dvc/data/raw/new_orleans_da.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 3cff5dac15bcb1e2603315f9c3e15bf0.dir
+  size: 39493
+  nfiles: 1
+  path: new_orleans_da

--- a/dvc/data/raw/new_orleans_harbor_pd.dvc
+++ b/dvc/data/raw/new_orleans_harbor_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: c62e46ee615faee707fce3d9334e4f1d.dir
+  size: 91167
+  nfiles: 3
+  path: new_orleans_harbor_pd

--- a/dvc/data/raw/new_orleans_pd.dvc
+++ b/dvc/data/raw/new_orleans_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 099df10e56b2398109cf7408110be478.dir
+  size: 1370021
+  nfiles: 3
+  path: new_orleans_pd

--- a/dvc/data/raw/new_orleans_so.dvc
+++ b/dvc/data/raw/new_orleans_so.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: a331db615512ad51a0e1091466107569.dir
+  size: 570279
+  nfiles: 5
+  path: new_orleans_so

--- a/dvc/data/raw/ouachita_da.dvc
+++ b/dvc/data/raw/ouachita_da.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: a4ad8b1b4c66d4896a235d24abd9768e.dir
+  size: 920
+  nfiles: 1
+  path: ouachita_da

--- a/dvc/data/raw/pineville_pd.dvc
+++ b/dvc/data/raw/pineville_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 851fda3f030988e71c3fe8d8f746dec2.dir
+  size: 1490
+  nfiles: 1
+  path: pineville_pd

--- a/dvc/data/raw/plaquemines_so.dvc
+++ b/dvc/data/raw/plaquemines_so.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: cf6e115131e420cf10e3d0dd6b6e75b3.dir
+  size: 33128
+  nfiles: 3
+  path: plaquemines_so

--- a/dvc/data/raw/ponchatoula_pd.dvc
+++ b/dvc/data/raw/ponchatoula_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: efbb3d20e96b216b780c6843d9968224.dir
+  size: 10066
+  nfiles: 2
+  path: ponchatoula_pd

--- a/dvc/data/raw/port_allen_csd.dvc
+++ b/dvc/data/raw/port_allen_csd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 3cf4a6d6a257970c88ceba8a6f13afec.dir
+  size: 5252
+  nfiles: 1
+  path: port_allen_csd

--- a/dvc/data/raw/port_allen_pd.dvc
+++ b/dvc/data/raw/port_allen_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: e63db5b2f05f3440b964798e77d5cbc6.dir
+  size: 5053
+  nfiles: 3
+  path: port_allen_pd

--- a/dvc/data/raw/post.dvc
+++ b/dvc/data/raw/post.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: a1d3e698aa0b5d324fd9086d7b3e06ba.dir
+  size: 64222
+  nfiles: 2
+  path: post

--- a/dvc/data/raw/post_council.dvc
+++ b/dvc/data/raw/post_council.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: ba2b36edd38008dfa40d5d8e7a7ffa4f.dir
+  size: 2798704
+  nfiles: 2
+  path: post_council

--- a/dvc/data/raw/rayne_pd.dvc
+++ b/dvc/data/raw/rayne_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 1b75406e23707d3f639f91d33863badc.dir
+  size: 8338
+  nfiles: 3
+  path: rayne_pd

--- a/dvc/data/raw/scott_pd.dvc
+++ b/dvc/data/raw/scott_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 4bd818c541f84c898d6ed5e0594df024.dir
+  size: 4921
+  nfiles: 3
+  path: scott_pd

--- a/dvc/data/raw/shreveport_pd.dvc
+++ b/dvc/data/raw/shreveport_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 415266bab7084921f57e599145aa912c.dir
+  size: 117787
+  nfiles: 5
+  path: shreveport_pd

--- a/dvc/data/raw/slidell_pd.dvc
+++ b/dvc/data/raw/slidell_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: fdde889bf2e71367dca864a078330228.dir
+  size: 231557
+  nfiles: 3
+  path: slidell_pd

--- a/dvc/data/raw/st_james_so.dvc
+++ b/dvc/data/raw/st_james_so.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 944310c29f5bdcaa325625cec4bb9f01.dir
+  size: 1030
+  nfiles: 1
+  path: st_james_so

--- a/dvc/data/raw/st_john_so.dvc
+++ b/dvc/data/raw/st_john_so.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: ed7f2d41c6b751b5a306210eef723c19.dir
+  size: 2195
+  nfiles: 1
+  path: st_john_so

--- a/dvc/data/raw/st_landry_so.dvc
+++ b/dvc/data/raw/st_landry_so.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 3c6ed07702967fef4122afb0ecebea01.dir
+  size: 8585
+  nfiles: 1
+  path: st_landry_so

--- a/dvc/data/raw/st_tammany_so.dvc
+++ b/dvc/data/raw/st_tammany_so.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 68c2f8654192e93650fd7ef622b530c6.dir
+  size: 241804
+  nfiles: 5
+  path: st_tammany_so

--- a/dvc/data/raw/sterlington_pd.dvc
+++ b/dvc/data/raw/sterlington_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 03990c0176334afc6a3c4cd79b5d5232.dir
+  size: 2340
+  nfiles: 1
+  path: sterlington_pd

--- a/dvc/data/raw/sulphur_pd.dvc
+++ b/dvc/data/raw/sulphur_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 036a7b6682f41cbf0a0644225f156450.dir
+  size: 1949
+  nfiles: 1
+  path: sulphur_pd

--- a/dvc/data/raw/tangipahoa_da.dvc
+++ b/dvc/data/raw/tangipahoa_da.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: f46af72de663665f58ff166d6312f9fe.dir
+  size: 383
+  nfiles: 1
+  path: tangipahoa_da

--- a/dvc/data/raw/tangipahoa_so.dvc
+++ b/dvc/data/raw/tangipahoa_so.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 050e1410809472d595a1a9b48d85292a.dir
+  size: 24538
+  nfiles: 2
+  path: tangipahoa_so

--- a/dvc/data/raw/terrebonne_so.dvc
+++ b/dvc/data/raw/terrebonne_so.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: c3858349ae7a68480611e2ba8778a538.dir
+  size: 432
+  nfiles: 1
+  path: terrebonne_so

--- a/dvc/data/raw/universities.dvc
+++ b/dvc/data/raw/universities.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: a6417cadb05ac016a8237d9ac1457811.dir
+  size: 4054622
+  nfiles: 1
+  path: universities

--- a/dvc/data/raw/vine.dvc
+++ b/dvc/data/raw/vine.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 6d241c15986c2a328eb434a87c58d457.dir
+  size: 2829
+  nfiles: 1
+  path: vine

--- a/dvc/data/raw/vivian_csd.dvc
+++ b/dvc/data/raw/vivian_csd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 0cb86cccd7455a8b25e085d4c65c7cce.dir
+  size: 1990
+  nfiles: 1
+  path: vivian_csd

--- a/dvc/data/raw/washington_so.dvc
+++ b/dvc/data/raw/washington_so.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 956e17f934a5d67f0310fc0c9e3248a1.dir
+  size: 1770
+  nfiles: 1
+  path: washington_so

--- a/dvc/data/raw/west_monroe_pd.dvc
+++ b/dvc/data/raw/west_monroe_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: a38e6234c6f9d73dfeb4339cd4631a31.dir
+  size: 12179
+  nfiles: 2
+  path: west_monroe_pd

--- a/dvc/data/raw/youngsville_pd.dvc
+++ b/dvc/data/raw/youngsville_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: 0aec4d3eccd0575b187c7b1924e2e9c7.dir
+  size: 6594
+  nfiles: 3
+  path: youngsville_pd

--- a/raw.dvc
+++ b/raw.dvc
@@ -1,6 +1,0 @@
-outs:
-- md5: f38e8ed5b8a35c98de9c00e86fc6c324.dir
-  size: 487304299
-  nfiles: 178
-  path: raw
-wdir: data

--- a/scripts/dvc_add.sh
+++ b/scripts/dvc_add.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -ex
+
+for folder in data/raw
+do
+    mkdir -p dvc/$folder || true
+    find $folder -type d -mindepth 1 -maxdepth 1 | xargs -I{} dvc add --file dvc/{}.dvc {}
+done


### PR DESCRIPTION
Address #302 

This PR splits `raw.dvc` into one dvc file per agency.

From now on, run `scripts/dvc_add.sh` to add things in `data/raw` folder. Because running `dvc add` will miss new folder/agency.