### PR TITLE
Fix circular dependencies for brady lists matching

### DIFF
--- a/.wrgl/config.yaml
+++ b/.wrgl/config.yaml
@@ -2,7 +2,7 @@ remote:
   origin:
     url: https://hub.wrgl.co/api/users/ipno/repos/data
     fetch:
-      - +refs/heads/*:refs/remotes/data/*
+      - +refs/heads/*:refs/remotes/origin/*
 branch:
   allegation:
     remote: origin

--- a/match/baton_rouge_da.py
+++ b/match/baton_rouge_da.py
@@ -25,9 +25,9 @@ def match_brady_to_personnel(brady, per):
         dfa,
         dfb,
     )
-    decision = 0.948
+    decision = 0.96
     matcher.save_pairs_to_excel(
-        deba.data("match/brady_baton_da_2021_v_personnel.xlsx"),
+        deba.data("match/brady_baton_da_2021_v_pprr_2021.xlsx"),
         decision,
     )
     matches = matcher.get_index_pairs_within_thresholds(lower_bound=decision)
@@ -38,7 +38,7 @@ def match_brady_to_personnel(brady, per):
 
 
 if __name__ == "__main__":
-    per = pd.read_csv(deba.data("fuse/personnel.csv"))
+    pprr = pd.read_csv(deba.data("match/pprr_baton_rouge_pd_2021.csv"))
     brady = pd.read_csv(deba.data("clean/brady_baton_rouge_da_2021.csv"))
-    brady = match_brady_to_personnel(brady, per)
+    brady = match_brady_to_personnel(brady, pprr)
     brady.to_csv(deba.data("match/brady_baton_rouge_da_2021.csv"), index=False)

--- a/match/new_orleans_da.py
+++ b/match/new_orleans_da.py
@@ -51,7 +51,7 @@ def match_brady_to_personnel(brady, per):
     )
     decision = 1
     matcher.save_pairs_to_excel(
-        deba.data("match/brady_new_orleans_da_2021_v_personnel.xlsx"),
+        deba.data("match/brady_new_orleans_da_2021_v_ipm_pprr.xlsx"),
         decision,
     )
     matches = matcher.get_index_pairs_within_thresholds(lower_bound=decision)
@@ -62,8 +62,8 @@ def match_brady_to_personnel(brady, per):
 
 
 if __name__ == "__main__":
-    per = pd.read_csv(deba.data("fuse/personnel.csv"))
+    pprr_ipm = pd.read_csv(deba.data("match/pprr_new_orleans_ipm_iapro_1946_2018.csv"))
     brady = pd.read_csv(deba.data("clean/brady_new_orleans_da_2021.csv"))
     brady = deduplicate_brady(brady)
-    brady = match_brady_to_personnel(brady, per)
+    brady = match_brady_to_personnel(brady, pprr_ipm)
     brady.to_csv(deba.data("match/brady_new_orleans_da_2021.csv"), index=False)

--- a/match/ouachita_da.py
+++ b/match/ouachita_da.py
@@ -2,14 +2,16 @@ from datamatch import ThresholdMatcher, JaroWinklerSimilarity, ColumnsIndex
 import deba
 import pandas as pd
 
+from lib.post import load_for_agency
 
-def match_brady_to_personnel(brady, per):
+
+def match_brady_to_personnel(brady, post):
     dfa = brady[["uid", "first_name", "last_name"]]
     dfa.loc[:, "fc"] = dfa.first_name.fillna("").map(lambda x: x[:1])
     dfa.loc[:, "lc"] = dfa.last_name.fillna("").map(lambda x: x[:1])
     dfa = dfa.drop_duplicates(subset=["uid"]).set_index("uid")
 
-    dfb = per[["uid", "first_name", "last_name"]]
+    dfb = post[["uid", "first_name", "last_name"]]
     dfb.loc[:, "first_name"] = dfb.first_name.str.lower().str.strip()
     dfb.loc[:, "last_name"] = dfb.last_name.str.lower().str.strip()
     dfb.loc[:, "fc"] = dfb.first_name.fillna("").map(lambda x: x[:1])
@@ -27,7 +29,7 @@ def match_brady_to_personnel(brady, per):
     )
     decision = 1
     matcher.save_pairs_to_excel(
-        deba.data("match/brady_ouachita_da_2021_v_personnel.xlsx"),
+        deba.data("match/brady_ouachita_da_2021_v_post_pprr.xlsx"),
         decision,
     )
     matches = matcher.get_index_pairs_within_thresholds(lower_bound=decision)
@@ -38,7 +40,7 @@ def match_brady_to_personnel(brady, per):
 
 
 if __name__ == "__main__":
-    per = pd.read_csv(deba.data("fuse/personnel.csv"))
+    post = load_for_agency("Ouachita SO")
     brady = pd.read_csv(deba.data("clean/brady_ouachita_da_2021.csv"))
-    brady = match_brady_to_personnel(brady, per)
+    brady = match_brady_to_personnel(brady, post)
     brady.to_csv(deba.data("match/brady_ouachita_da_2021.csv"), index=False)

--- a/match/tangipahoa_da.py
+++ b/match/tangipahoa_da.py
@@ -2,14 +2,16 @@ from datamatch import JaroWinklerSimilarity, ThresholdMatcher, ColumnsIndex
 import deba
 import pandas as pd
 
+from lib.post import load_for_agency
 
-def match_brady_to_personnel(brady, per):
+
+def match_brady_to_personnel(brady, post):
     dfa = brady[["first_name", "last_name", "uid"]]
     dfa.loc[:, "fc"] = dfa.first_name.fillna("").map(lambda x: x[:1])
     dfa.loc[:, "lc"] = dfa.last_name.fillna("").map(lambda x: x[:1])
     dfa = dfa.drop_duplicates(subset=["uid"]).set_index("uid")
 
-    dfb = per[["first_name", "last_name", "uid"]]
+    dfb = post[["first_name", "last_name", "uid"]]
     dfb.loc[:, "first_name"] = dfb.first_name.str.lower().str.strip()
     dfb.loc[:, "last_name"] = dfb.last_name.str.lower().str.strip()
     dfb.loc[:, "fc"] = dfb.first_name.fillna("").map(lambda x: x[:1])
@@ -25,9 +27,9 @@ def match_brady_to_personnel(brady, per):
         dfa,
         dfb,
     )
-    decision = 0.967
+    decision = 1
     matcher.save_pairs_to_excel(
-        deba.data("match/cprr_tangipahoa_da_2021_v_personnel.xlsx"), decision
+        deba.data("match/brady_tangipahoa_da_2021_v_post_pprr.xlsx"), decision
     )
     matches = matcher.get_index_pairs_within_thresholds(lower_bound=decision)
     match_dict = dict(matches)
@@ -37,7 +39,7 @@ def match_brady_to_personnel(brady, per):
 
 
 if __name__ == "__main__":
-    per = pd.read_csv(deba.data("fuse/personnel.csv"))
+    post = load_for_agency("Tangipahoa SO")
     brady = pd.read_csv(deba.data("clean/brady_tangipahoa_da_2021.csv"))
-    brady = match_brady_to_personnel(brady, per)
+    brady = match_brady_to_personnel(brady, post)
     brady.to_csv(deba.data("match/brady_tangipahoa_da_2021.csv"), index=False)

--- a/wrgl.mk
+++ b/wrgl.mk
@@ -1,7 +1,7 @@
 WRGL := wrgl
 
 pull_person: | $(BUILD_DIR)
-	@if [[ ! -f $(BUILD_DIR)/person.csv || "$(shell $(WRGL) pull $(WRGL_FLAGS) person)" != *"Already up to date."* ]]; then \
+	@if [[ ! -f $(BUILD_DIR)/person.csv || "$(shell $(WRGL) pull person origin +refs/heads/person:refs/remotes/origin/person $(WRGL_FLAGS))" != *"Already up to date."* ]]; then \
 		$(WRGL) export $(WRGL_FLAGS) person > $(BUILD_DIR)/person.csv && \
 		echo 'exported person branch to file $(BUILD_DIR)/person.csv'; \
 	else \


### PR DESCRIPTION
- In brady list matching scripts, Replace `fuse/personnel.csv` with other files (POST data in some cases) to eliminate circular dependencies.
- `pull_person` rule will only pull the `person` branch and nothing else.

@ayyubibrahimi  after this is merged, you should be able to run `make` and end up with the `.wrgl` folder just taking 125Mb which is just the `person` branch. I hope your computer can take on that much at least.

Also please review how I have changed the brady matching scripts. We really can't feed the brady output into generating `fuse/personnel.csv` only to feed this file into generating the brady files again. Just match the brady lists with any relevant personnel data from the same area. Or if there's nothing like that then just match against the POST data.