### PR TITLE
Enhancement/pib_annual_reports

### DIFF
--- a/.github/workflows/process_data.yml
+++ b/.github/workflows/process_data.yml
@@ -21,6 +21,10 @@ jobs:
         run: |
           curl http://archive.ubuntu.com/ubuntu/pool/main/m/make-dfsg/make_4.3-4ubuntu1_amd64.deb > ~/make_4.3-4ubuntu1_amd64.deb
           sudo apt-get install ~/make_4.3-4ubuntu1_amd64.deb
+      - name: install poppler-utils
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y poppler-utils
       - run: pip install -r requirements.txt
       - name: install wrgl
         run: sudo bash -c 'curl -L https://github.com/wrgl/wrgl/releases/latest/download/install.sh | bash'

--- a/.github/workflows/process_data.yml
+++ b/.github/workflows/process_data.yml
@@ -21,10 +21,12 @@ jobs:
         run: |
           curl http://archive.ubuntu.com/ubuntu/pool/main/m/make-dfsg/make_4.3-4ubuntu1_amd64.deb > ~/make_4.3-4ubuntu1_amd64.deb
           sudo apt-get install ~/make_4.3-4ubuntu1_amd64.deb
-      - name: install poppler-utils
+      - name: install poppler-utils and tesseract
         run: |
-          sudo apt-get update -y
-          sudo apt-get install -y poppler-utils
+          sudo apt update -y
+          sudo apt install -y poppler-utils
+          sudo add-apt-repository ppa:alex-p/tesseract-ocr-devel
+          sudo apt install -y tesseract-ocr
       - run: pip install -r requirements.txt
       - name: install wrgl
         run: sudo bash -c 'curl -L https://github.com/wrgl/wrgl/releases/latest/download/install.sh | bash'

--- a/clean/nopd_pib_reports.py
+++ b/clean/nopd_pib_reports.py
@@ -1,6 +1,6 @@
 import deba
 import pandas as pd
-from lib.clean import names_to_title_case
+from lib.clean import names_to_title_case, standardize_desc_cols
 from lib.columns import set_values
 from lib.uid import gen_uid
 
@@ -236,6 +236,17 @@ def clean():
         .pipe(extract_allegation_made)
         .pipe(extract_investigation_status)
         .pipe(merge_split_tables)
+        .pipe(
+            standardize_desc_cols,
+            [
+                "allegation_desc",
+                "allegation",
+                "tracking_id",
+                "action",
+                "badge_no",
+                "disposition",
+            ],
+        )
         .pipe(names_to_title_case, ["tracking_id"])
         .pipe(set_values, {"agency": "New Orleans PD"})
     )

--- a/clean/nopd_pib_reports.py
+++ b/clean/nopd_pib_reports.py
@@ -1,0 +1,247 @@
+import deba
+import pandas as pd
+from lib.columns import set_values
+from lib.uid import gen_uid
+
+
+def stack_df(df):
+    df = df[
+        [
+            "allegation",
+            "allegation_1",
+            "allegation_2",
+            "allegation_3",
+            "allegation_4",
+            "allegation_5",
+            "allegation_6",
+            "allegation_7",
+            "allegation_8",
+            "allegation_9",
+            "allegation_10",
+            "allegation_11",
+            "allegation_12",
+            "allegation_13",
+            "allegation_14",
+            "allegation_15",
+            "allegation_16",
+            "allegation_17",
+            "allegation_18",
+            "allegation_19",
+            "allegation_20",
+            "allegation_21",
+            "allegation_22",
+            "allegation_23",
+            "allegation_24",
+            "allegation_25",
+            "allegation_26",
+            "allegation_27",
+            "allegation_28",
+            "allegation_29",
+            "allegation_30",
+            "allegation_31",
+            "allegation_32",
+            "allegation_33",
+            "allegation_34",
+            "allegation_35",
+            "allegation_36",
+            "allegation_37",
+            "allegation_38",
+        ]
+    ].stack()
+
+    df.name = "allegation"
+    df = df.reset_index().drop(columns=["level_0", "level_1"])
+
+    return df
+
+
+def clean_allegation(df):
+    df.loc[:, "allegation"] = (
+        df.allegation.str.lower()
+        .str.strip()
+        .str.replace(r"^ +", "", regex=True)
+        .str.replace(r"\n+?", " ", regex=True)
+        .str.replace(r"received:? ", "", regex=True)
+        .str.replace(r"\n+", "", regex=True)
+        .str.replace(
+            r"\ballegation:? nfim\b", "no formal investigation merited", regex=True
+        )
+        .str.replace(r"\(?nfim\)?", "", regex=True)
+    )
+    return df
+
+
+def extract_tracking_id(df):
+    tracking = df.allegation.str.replace(
+        r"(complaint tracking number:?|control number:?)", "", regex=True
+    ).str.extract(r"(201[456789]-\w{4}[\.-]\w)[:_]?")
+    df.loc[:, "tracking_id"] = tracking[0]
+    return df
+
+
+def extract_receive_date(df):
+    dates = df.allegation.str.replace(
+        r"(\w{1,2})-(\w{1,2})-(\w{2,4})", r"\1/\2/\3", regex=True
+    ).str.extract(r"(\w{1,2}\/\w{1,2}\/\w{2,4})")
+    df.loc[:, "receive_date"] = dates[0]
+    return df
+
+
+def extract_disposition(df):
+    dispositions = (
+        df.allegation.str.lower()
+        .str.strip()
+        .str.replace(r"disposition:? (na|none)", "no disposition", regex=True)
+        .str.extract(
+            r"(sustained|di-2|no formal investigation merited|\bnot sustained\b|"
+            r"exonerated|mediation|negotiated settlement|pending\b;? ?(investigation)?|"
+            r"unfounded|duplicate investigation|withdrawn|rui|resigned under investigation"
+            r"\bprescribed-sustained\b|greviance|investigation pending|cancelled|no disposition)"
+        )
+    )
+
+    df.loc[:, "disposition"] = dispositions[0]
+    return df
+
+
+def extract_actions(df):
+    actions = df.allegation.str.replace(
+        r"(action ?(taken)?|discipline):? (na|none)", "no action", regex=True
+    ).str.extract(
+        r"no disposition|(\w+?-? ?d?a?y?s? suspension\b|none|hearing pending|"
+        r"investigation pending|awaiting hearing|(withdrawn)? ?-? mediation|"
+        r"rui -? ?(resigned ?(under investigation)?)?|"
+        r"verbal counseling|rui - retired|"
+        r"oral reprimand|none -nfim|n?s?a? ?-? letter of reprimand|none - exonerated|"
+        r"duplicate allegation|dismissed|no action|remedial training|written documentation)"
+    )
+    df.loc[:, "action"] = actions[0].str.replace(r"sustained ", "", regex=False)
+    return df
+
+
+def extract_investigation_status(df):
+    statuses = df.allegation.str.replace(r"(\w+) +$", r"\1", regex=True).str.extract(
+        r"(forwarded$|completed$)"
+    )
+    df.loc[:, "investigation_status"] = statuses[0]
+    return df
+
+
+def extract_allegation_desc(df):
+    allegation_desc = (
+        df.allegation.str.replace(r"^ +?(\w+)", r"\1", regex=True)
+        .str.replace(r"(\w+)  +(\w+)", r"\1 \2", regex=True)
+        .str.replace(r"complaint tracking number:?", "", regex=True)
+        .str.replace(r"performance of duty\b", "", regex=True)
+        .str.replace(r"letter of reprimand\b", "", regex=True)
+        .str.extract(
+            r"(t?h?e? ?(detective|complaina?n?t?|officers?e?d?|accused"
+            r"|employees?|victims?|supervisors|persons|man|evidence|technician|"
+            r"destroying|public|counselor|investigation cancelled|inmates?).+)"
+        )
+    )
+    df.loc[:, "allegation_desc"] = (
+        allegation_desc[0]
+        .str.replace(r"( disposition:?(.+)| discipline:?(.+))", "", regex=True)
+        .str.replace(r"^mand ?", "", regex=True)
+    )
+    return df
+
+
+def extract_allegation_made(df):
+    allegations = (
+        df.allegation.str.replace(r"(\w+) \/ (\w+)", r"\1 \2", regex=True)
+        .str.replace(r"orders ?[&\/]? ?directives", "orders and directives", regex=True)
+        .str.replace(r"nfim", "no further investigation merited", regex=True)
+        .str.replace(r"; professionalism", "; allegation: professionalsim", regex=False)
+        .str.extract(r"allegations?:? (\w+ ?(\w+)? ?(\w+)? ?(\w+)? ?(\w+)?) ?;?")
+    )
+    df.loc[:, "allegation_made"] = allegations[0].str.replace(
+        r"(duty|law|retaliation|professionalism).+", r"\1", regex=True
+    )
+    return df[~((df.tracking_id.fillna("") == ""))]
+
+
+## before merge, make sure that tracking_id is effeciently extracted
+
+
+def merge_2019_data(df):
+    og_df = df[~df["tracking_id"].str.contains("2019")]
+
+    df_2019 = df[df["tracking_id"].str.contains("2019")]
+
+    dfa = df_2019[~((df_2019.investigation_status.fillna("") == ""))]
+    dfa.loc[:, "receive_date"] = dfa.receive_date.fillna("")
+    dfa.loc[:, "tracking_id"] = df.tracking_id.str.replace(r"-o", "-0", regex=False)
+
+    badges = dfa.allegation.str.replace(
+        r"(\w+)  +(\w+)", r"\1 \2", regex=True
+    ).str.extract(
+        r"(\w{3,5}) (di-2|not|sustained|exonerated|none"
+        r"|greviance|rui|negotiated|unfounded|cancelled|duplicate|case|withdrawn)"
+    )
+
+    dfa.loc[:, "badge_no"] = badges[0]
+
+    dfb = df_2019[~((df_2019.receive_date == ""))]
+
+    clean_df_2019 = pd.merge(dfa, dfb, on="tracking_id", how="outer")
+
+    clean_df_2019 = (
+        clean_df_2019.drop(
+            columns=[
+                "investigation_status_y",
+                "allegation_x",
+                "allegation_y",
+                "allegation_made_x",
+                "allegation_made_y",
+                "disposition_y",
+                "action_y",
+                "receive_date_x",
+                "allegation_desc_x",
+            ]
+        )
+        .rename(
+            columns={
+                "disposition_x": "disposition",
+                "action_x": "action",
+                "investigation_status_x": "investigation_status",
+                "badge_no_x": "badge_no",
+                "receive_date_y": "receive_date",
+                "allegation_desc_y": "allegation_desc",
+            }
+        )
+        .drop_duplicates(subset=["tracking_id", "badge_no"])
+    )
+
+    clean_df_2019 = clean_df_2019[~((clean_df_2019.badge_no.fillna("") == ""))]
+
+    df = pd.concat([og_df, clean_df_2019], axis=0)
+    return (
+        df.drop(columns=["allegation"])
+        .rename(columns={"allegation_made": "allegation"})
+        .fillna("")
+    )
+
+
+def clean():
+    df = (
+        pd.read_csv(deba.data("ner/nopd_pib_reports_2014_2019.csv"))
+        .pipe(stack_df)
+        .pipe(clean_allegation)
+        .pipe(extract_tracking_id)
+        .pipe(extract_receive_date)
+        .pipe(extract_disposition)
+        .pipe(extract_actions)
+        .pipe(extract_allegation_desc)
+        .pipe(extract_allegation_made)
+        .pipe(extract_investigation_status)
+        .pipe(merge_2019_data)
+        .pipe(set_values, {"agency": "New Orleans PD"})
+    )
+    return df
+
+
+if __name__ == "__main__":
+    df = clean()
+    df.to_csv(deba.data("clean/cprr_new_orleans_pd_pib_reports.csv"), index=False)

--- a/clean/nopd_pib_reports.py
+++ b/clean/nopd_pib_reports.py
@@ -1,5 +1,6 @@
 import deba
 import pandas as pd
+from lib.clean import names_to_title_case
 from lib.columns import set_values
 from lib.uid import gen_uid
 
@@ -95,7 +96,7 @@ def extract_disposition(df):
         .str.extract(
             r"(sustained|di-2|no formal investigation merited|\bnot sustained\b|"
             r"exonerated|mediation|negotiated settlement|pending\b;? ?(investigation)?|"
-            r"unfounded|duplicate investigation|withdrawn|rui|resigned under investigation"
+            r"unfounded|duplicate investigation|withdrawn|rui\b|resigned under investigation"
             r"\bprescribed-sustained\b|greviance|investigation pending|cancelled|no disposition)"
         )
     )
@@ -237,6 +238,7 @@ def clean():
         .pipe(extract_allegation_made)
         .pipe(extract_investigation_status)
         .pipe(merge_2019_data)
+        .pipe(names_to_title_case, ["tracking_id"])
         .pipe(set_values, {"agency": "New Orleans PD"})
     )
     return df
@@ -244,4 +246,4 @@ def clean():
 
 if __name__ == "__main__":
     df = clean()
-    df.to_csv(deba.data("clean/cprr_new_orleans_pd_pib_reports.csv"), index=False)
+    df.to_csv(deba.data("clean/cprr_new_orleans_pd_pib_reports_2014_2019.csv"), index=False)

--- a/deba.yaml
+++ b/deba.yaml
@@ -38,3 +38,9 @@ overrides:
       - $(DEBA_MD5_DIR)/meta/post_officer_history_reports.py.md5
       - $(DEBA_MD5_DIR)/raw_post_officer_history_reports.dvc.md5 
     recipe: "$(call deba_execute,meta/post_officer_history_reports.py)"
+  - target:
+      - meta/nopd_pib_reports_files_2014_2019.csv
+    prerequisites:
+      - $(DEBA_MD5_DIR)/meta/nopd_pib_reports.py.md5
+      - $(DEBA_MD5_DIR)/raw_nopd_pib_reports.dvc.md5 
+    recipe: "$(call deba_execute,meta/nopd_pib_reports.py)"

--- a/deba.yaml
+++ b/deba.yaml
@@ -39,7 +39,7 @@ overrides:
       - $(DEBA_MD5_DIR)/raw_post_officer_history_reports.dvc.md5 
     recipe: "$(call deba_execute,meta/post_officer_history_reports.py)"
   - target:
-      - meta/nopd_pib_reports_files_2014_2019.csv
+      - meta/nopd_pib_report_files_2014_2019.csv
     prerequisites:
       - $(DEBA_MD5_DIR)/meta/nopd_pib_reports.py.md5
       - $(DEBA_MD5_DIR)/raw_nopd_pib_reports.dvc.md5 

--- a/dvc/data/raw/baker_pd.dvc
+++ b/dvc/data/raw/baker_pd.dvc
@@ -1,6 +1,6 @@
 wdir: ../../../data/raw
 outs:
-- md5: 50256a0059595867250fd90706d294c8.dir
-  size: 9842
+- md5: fd5f2ca26869fb62559bd6ccbb5d3a6b.dir
+  size: 7230
   nfiles: 3
   path: baker_pd

--- a/dvc/data/raw/new_orleans_pd.dvc
+++ b/dvc/data/raw/new_orleans_pd.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: eda1d4ac2891abcfaa7d69b23e008d29.dir
+  size: 8378981
+  nfiles: 23
+  path: new_orleans_pd

--- a/dvc/data/raw/new_orleans_pd.dvc
+++ b/dvc/data/raw/new_orleans_pd.dvc
@@ -1,6 +1,6 @@
 wdir: ../../../data/raw
 outs:
 - md5: eda1d4ac2891abcfaa7d69b23e008d29.dir
-  size: 8378981
+  size: 8379134
   nfiles: 23
   path: new_orleans_pd

--- a/dvc/data/raw/new_orleans_pd.dvc
+++ b/dvc/data/raw/new_orleans_pd.dvc
@@ -1,6 +1,0 @@
-wdir: ../../../data/raw
-outs:
-- md5: 920968c1bee4b31dcff52822cc0dcf8a.dir
-  size: 4075028
-  nfiles: 8
-  path: new_orleans_pd

--- a/dvc/data/raw/post_officer_history.dvc
+++ b/dvc/data/raw/post_officer_history.dvc
@@ -1,0 +1,6 @@
+wdir: ../../../data/raw
+outs:
+- md5: b8bc7e6f1d623ce5f582a781dcabded2.dir
+  size: 256033
+  nfiles: 1
+  path: post_officer_history

--- a/fuse/new_orleans_pd.py
+++ b/fuse/new_orleans_pd.py
@@ -255,7 +255,7 @@ if __name__ == "__main__":
 
     complaints = fuse_cprr(cprr, actions, officer_number_dict)
     pib = fuse_pib(pib, officer_number_dict)
-    com = rearrange_allegation_columns(pd.concat([complaints, pib]))
+    com = rearrange_allegation_columns(pd.concat([complaints, pib]).drop_duplicates(subset=["allegation_uid"], keep="last"))
     personnel = fuse_personnel(
         pprr_ipm,
         lprr,

--- a/fuse/new_orleans_pd.py
+++ b/fuse/new_orleans_pd.py
@@ -32,7 +32,15 @@ def fuse_cprr(cprr, actions, officer_number_dict):
     )
     # cprr.loc[:, 'action'] = cprr.allegation_primary_key.map(
     #     lambda x: actions_dict.get(x, ''))
-    return rearrange_allegation_columns(cprr)
+    return cprr
+
+
+def fuse_pib(pib, officer_number_dict):
+    pib = float_to_int_str(cprr, ["officer_primary_key"])
+    pib.loc[:, "uid"] = cprr.officer_primary_key.map(
+        lambda x: officer_number_dict.get(x, "")
+    )
+    return pib
 
 
 def fuse_events(
@@ -242,9 +250,12 @@ if __name__ == "__main__":
     pprr_separations = pd.read_csv(
         deba.data("match/pprr_seps_new_orleans_pd_2018_2021.csv")
     )
+    pib = pd.read_csv(deba.data("match/cprr_new_orleans_pib_reports_2014_2019.csv"))
     brady = brady.loc[brady.agency == "New Orleans PD"]
 
     complaints = fuse_cprr(cprr, actions, officer_number_dict)
+    pib = fuse_pib(pib, officer_number_dict)
+    com = rearrange_allegation_columns(pd.concat([complaints, pib]))
     personnel = fuse_personnel(
         pprr_ipm,
         lprr,
@@ -274,7 +285,7 @@ if __name__ == "__main__":
     uof_df = rearrange_use_of_force(uof)
     brady_df = rearrange_brady_columns(brady)
     pclaims_df = rearrange_property_claims_columns(pd.concat([pclaims20, pclaims21]))
-    complaints.to_csv(deba.data("fuse/com_new_orleans_pd.csv"), index=False)
+    com.to_csv(deba.data("fuse/com_new_orleans_pd.csv"), index=False)
     personnel.to_csv(deba.data("fuse/per_new_orleans_pd.csv"), index=False)
     events_df.to_csv(deba.data("fuse/event_new_orleans_pd.csv"), index=False)
     lprr_df.to_csv(deba.data("fuse/app_new_orleans_csc.csv"), index=False)

--- a/fuse/new_orleans_pd.py
+++ b/fuse/new_orleans_pd.py
@@ -36,8 +36,8 @@ def fuse_cprr(cprr, actions, officer_number_dict):
 
 
 def fuse_pib(pib, officer_number_dict):
-    pib = float_to_int_str(cprr, ["officer_primary_key"])
-    pib.loc[:, "uid"] = cprr.officer_primary_key.map(
+    pib = float_to_int_str(pib, ["officer_primary_key"])
+    pib.loc[:, "uid"] = pib.officer_primary_key.map(
         lambda x: officer_number_dict.get(x, "")
     )
     return pib

--- a/fuse/new_orleans_pd.py
+++ b/fuse/new_orleans_pd.py
@@ -250,7 +250,7 @@ if __name__ == "__main__":
     pprr_separations = pd.read_csv(
         deba.data("match/pprr_seps_new_orleans_pd_2018_2021.csv")
     )
-    pib = pd.read_csv(deba.data("match/cprr_new_orleans_pib_reports_2014_2019.csv"))
+    pib = pd.read_csv(deba.data("match/cprr_new_orleans_pib_reports_2014_2020.csv"))
     brady = brady.loc[brady.agency == "New Orleans PD"]
 
     complaints = fuse_cprr(cprr, actions, officer_number_dict)

--- a/lib/ner.py
+++ b/lib/ner.py
@@ -38,14 +38,15 @@ def train_spacy_model(df: pd.DataFrame, training_data: str) -> pd.DataFrame:
         random.shuffle(TRAINING_DATA)
         losses = {}
         for batch in spacy.util.minibatch(
-            TRAINING_DATA, size=compounding(3.0, 1.5, 1.001)
+            TRAINING_DATA, size=compounding(3.0, 2.0, 1.001)
         ):
             for text, annotations in batch:
                 doc = nlp.make_doc(text)
                 example = Example.from_dict(doc, annotations)
                 nlp.update([example], sgd=optimizer, losses=losses, drop=0.4)
                 print(losses)
-    return ner
+        entities = []
+    return nlp
 
 
 def apply_spacy_model(df: pd.DataFrame, spacy_model: str) -> pd.DataFrame:

--- a/lib/ner.py
+++ b/lib/ner.py
@@ -1,0 +1,73 @@
+import json
+import random
+import spacy
+from spacy.util import minibatch, compounding
+from spacy.training import Example
+import pandas as pd
+import deba
+
+
+def train_spacy_model(df: pd.DataFrame, training_data: str) -> pd.DataFrame:
+    ###  import labeled_data that has been exported from doccano
+
+    labeled_data = []
+    with open(
+        training_data,
+        "r",
+    ) as read_file:
+        for line in read_file:
+            data = json.loads(line)
+            labeled_data.append(data)
+
+    TRAINING_DATA = []
+    for entry in labeled_data:
+        entities = []
+        for e in entry["label"]:
+            entities.append((e[0], e[1], e[2]))
+        spacy_entry = (entry["data"], {"entities": entities})
+        TRAINING_DATA.append(spacy_entry)
+
+    ### train model
+    nlp = spacy.blank("en")
+    ner = nlp.create_pipe("ner")
+    nlp.add_pipe("ner")
+    ner.add_label("allegation")
+
+    optimizer = nlp.begin_training()
+    for itn in range(200):
+        random.shuffle(TRAINING_DATA)
+        losses = {}
+        for batch in spacy.util.minibatch(
+            TRAINING_DATA, size=compounding(3.0, 1.5, 1.001)
+        ):
+            for text, annotations in batch:
+                doc = nlp.make_doc(text)
+                example = Example.from_dict(doc, annotations)
+                nlp.update([example], sgd=optimizer, losses=losses, drop=0.4)
+                print(losses)
+    return ner
+
+
+def apply_spacy_model(df: pd.DataFrame, spacy_model: str) -> pd.DataFrame:
+    nlp = spacy_model
+    ### train model
+    entities = []
+    for row in df["text"].apply(nlp):
+        text = [text.text for text in row.ents]
+        labels = [labels.label_ for labels in row.ents]
+        ents = list(zip(labels, text))
+
+        tuples = [i[0] for i in ents]
+        counts = {key: tuples.count(key) for key in [i[0] for i in ents]}
+        for idx, key in enumerate(tuples):
+            if counts.get(key) and counts.get(key) > 1:
+                for num in range(counts[key]):
+                    if key + str(num + 1) not in tuples:
+                        tuples.remove(key)
+                        tuples.insert(idx + num, key + "_" + str(num + 1))
+
+        renamed_ents = dict(zip(tuples, [i[1] for i in ents]))
+        entities.append(renamed_ents)
+
+    ner = pd.DataFrame(entities)
+    return ner

--- a/lib/ocr.py
+++ b/lib/ocr.py
@@ -74,8 +74,6 @@ def process_pdf(df: pd.DataFrame, dir_name: str) -> pd.DataFrame:
             ):
                 txt = pytesseract.image_to_string(image)
                 pages.append(txt)
-            image.close()
-            del image
 
         with open(ocr_cachefile, "w") as f:
             json.dump(pages, f)

--- a/lib/ocr.py
+++ b/lib/ocr.py
@@ -65,7 +65,7 @@ def process_pdf(df: pd.DataFrame, dir_name: str) -> pd.DataFrame:
 
         pages = []
         with tempfile.TemporaryDirectory() as path:
-            images = convert_from_path(pdfpath, dpi=300, output_folder=path)
+            images = convert_from_path(pdfpath, dpi=500, output_folder=path)
             for image in tqdm(
                 images,
                 desc="processing %s" % os.path.relpath(pdfpath, str(root_dir)),

--- a/lib/ocr.py
+++ b/lib/ocr.py
@@ -77,7 +77,7 @@ def process_pdf(
                 continue
 
         pages = []
-        kwargs = {"dpi": 100, "fmt": "pdf"}
+        kwargs = {"dpi": 100}
         if output_images_to_tempdir:
             tempdir = tempfile.TemporaryDirectory()
             kwargs["output_folder"] = tempdir.name

--- a/lib/ocr.py
+++ b/lib/ocr.py
@@ -65,7 +65,7 @@ def process_pdf(df: pd.DataFrame, dir_name: str) -> pd.DataFrame:
 
         pages = []
         with tempfile.TemporaryDirectory() as path:
-            images = convert_from_path(pdfpath, dpi=500, output_folder=path)
+            images = convert_from_path(pdfpath, dpi=100, output_folder=path, fmt="pdf")
             for image in tqdm(
                 images,
                 desc="processing %s" % os.path.relpath(pdfpath, str(root_dir)),
@@ -74,6 +74,8 @@ def process_pdf(df: pd.DataFrame, dir_name: str) -> pd.DataFrame:
             ):
                 txt = pytesseract.image_to_string(image)
                 pages.append(txt)
+            image.close()
+            del image
 
         with open(ocr_cachefile, "w") as f:
             json.dump(pages, f)

--- a/match/new_orleans_pd.py
+++ b/match/new_orleans_pd.py
@@ -8,7 +8,7 @@ from datamatch import (
 )
 from lib.post import extract_events_from_post, load_for_agency
 import pandas as pd
-from lib.clean import canonicalize_officers
+from lib.clean import canonicalize_officers, float_to_int_str
 
 
 def deduplicate_pprr(pprr):
@@ -450,6 +450,7 @@ def join_pib_and_ipm():
                 "allegation_y": "allegation",
             }
         )
+        .pipe(float_to_int_str, ["officer_primary_key"])
     )
 
 

--- a/match/new_orleans_pd.py
+++ b/match/new_orleans_pd.py
@@ -430,6 +430,29 @@ def match_pprr_separations_to_pprr(pprr_seps, pprr_ipm):
     return pprr_seps
 
 
+def join_pib_and_ipm():
+    pib = pd.read_csv(
+        deba.data("clean/cprr_new_orleans_pd_pib_reports_2014_2019.csv")
+    ).drop_duplicates(subset=["tracking_id"], keep=False)
+    ipm = pd.read_csv(
+        deba.data("clean/cprr_new_orleans_pd_1931_2020.csv")
+    ).drop_duplicates(subset=["tracking_id"], keep=False)
+
+    df = pd.merge(pib, ipm, on="tracking_id", how="outer")
+    df = df[~((df.allegation_desc.fillna("") == ""))]
+    return (
+        df[~((df.officer_primary_key.fillna("") == ""))]
+        .drop(columns=["allegation_x", "disposition_y", "agency_y"])
+        .rename(
+            columns={
+                "agency_x": "agency",
+                "disposition_x": "disposition",
+                "allegation_y": "allegation",
+            }
+        )
+    )
+
+
 if __name__ == "__main__":
     pprr_ipm = pd.read_csv(deba.data("clean/pprr_new_orleans_ipm_iapro_1946_2018.csv"))
     pprr_csd = pd.read_csv(deba.data("clean/pprr_new_orleans_csd_2014.csv"))
@@ -446,6 +469,7 @@ if __name__ == "__main__":
     pprr_separations = pd.read_csv(
         deba.data("clean/pprr_seps_new_orleans_pd_2018_2021.csv")
     )
+    pib = join_pib_and_ipm()
     award = deduplicate_award(award)
     event_df = match_pprr_against_post(pprr_ipm, post)
     award = match_award_to_pprr_ipm(award, pprr_ipm)
@@ -473,4 +497,7 @@ if __name__ == "__main__":
     pclaims21.to_csv(deba.data("match/pclaims_new_orleans_pd_2021.csv"), index=False)
     pprr_separations.to_csv(
         deba.data("match/pprr_seps_new_orleans_pd_2018_2021.csv"), index=False
+    )
+    pib.to_csv(
+        deba.data("match/cprr_new_orleans_pib_reports_2014_2019.csv"), index=False
     )

--- a/match/new_orleans_pd.py
+++ b/match/new_orleans_pd.py
@@ -432,7 +432,7 @@ def match_pprr_separations_to_pprr(pprr_seps, pprr_ipm):
 
 def join_pib_and_ipm():
     pib = pd.read_csv(
-        deba.data("clean/cprr_new_orleans_pd_pib_reports_2014_2019.csv")
+        deba.data("clean/cprr_new_orleans_pd_pib_reports_2014_2020.csv")
     ).drop_duplicates(subset=["tracking_id"], keep=False)
     ipm = pd.read_csv(
         deba.data("clean/cprr_new_orleans_pd_1931_2020.csv")
@@ -499,5 +499,5 @@ if __name__ == "__main__":
         deba.data("match/pprr_seps_new_orleans_pd_2018_2021.csv"), index=False
     )
     pib.to_csv(
-        deba.data("match/cprr_new_orleans_pib_reports_2014_2019.csv"), index=False
+        deba.data("match/cprr_new_orleans_pib_reports_2014_2020.csv"), index=False
     )

--- a/meta/nopd_pib_reports.py
+++ b/meta/nopd_pib_reports.py
@@ -31,4 +31,4 @@ def fetch_reports() -> pd.DataFrame:
 
 if __name__ == "__main__":
     df = fetch_reports()
-    df.to_csv(deba.data("meta/nopd_pib_reports_files_2014_2019.csv"), index=False)
+    df.to_csv(deba.data("meta/nopd_pib_report_files_2014_2019.csv"), index=False)

--- a/meta/nopd_pib_reports.py
+++ b/meta/nopd_pib_reports.py
@@ -1,0 +1,34 @@
+import deba
+from lib.dvc import files_meta_frame
+import pandas as pd
+
+
+def set_filetype(df: pd.DataFrame) -> pd.DataFrame:
+    df.loc[df.filepath.str.lower().str.endswith(".pdf"), "filetype"] = "pdf"
+    return df
+
+
+def split_filepath(df: pd.DataFrame) -> pd.DataFrame:
+    filepaths = df.filepath.str.split("/")
+    df.loc[:, "fn"] = filepaths.map(lambda v: v[:])
+    return df
+
+
+def set_file_category(df: pd.DataFrame) -> pd.DataFrame:
+    column = "file_category"
+    df.loc[df.fn.astype(str).str.match(r"(.+)"), column] = "nopd_pib_annual_report"
+    return df
+
+
+def fetch_reports() -> pd.DataFrame:
+    return (
+        files_meta_frame("raw_nopd_pib_reports.dvc")
+        .pipe(set_filetype)
+        .pipe(split_filepath)
+        .pipe(set_file_category)
+    )
+
+
+if __name__ == "__main__":
+    df = fetch_reports()
+    df.to_csv(deba.data("meta/nopd_pib_reports_files_2014_2019.csv"), index=False)

--- a/meta/nopd_pib_reports.py
+++ b/meta/nopd_pib_reports.py
@@ -22,7 +22,7 @@ def set_file_category(df: pd.DataFrame) -> pd.DataFrame:
 
 def fetch_reports() -> pd.DataFrame:
     return (
-        files_meta_frame("raw_post_officer_history_reports.dvc")
+        files_meta_frame("raw_nopd_pib_reports.dvc")
         .pipe(set_filetype)
         .pipe(split_filepath)
         .pipe(set_file_category)
@@ -31,4 +31,4 @@ def fetch_reports() -> pd.DataFrame:
 
 if __name__ == "__main__":
     df = fetch_reports()
-    df.to_csv(deba.data("meta/nopd_pib_report_files_2014_2019.csv"), index=False)
+    df.to_csv(deba.data("meta/nopd_pib_report_files_2014_2020.csv"), index=False)

--- a/meta/nopd_pib_reports.py
+++ b/meta/nopd_pib_reports.py
@@ -22,7 +22,7 @@ def set_file_category(df: pd.DataFrame) -> pd.DataFrame:
 
 def fetch_reports() -> pd.DataFrame:
     return (
-        files_meta_frame("raw_nopd_pib_reports.dvc")
+        files_meta_frame("raw_post_officer_history_reports.dvc")
         .pipe(set_filetype)
         .pipe(split_filepath)
         .pipe(set_file_category)

--- a/ner/nopd_pib_reports.py
+++ b/ner/nopd_pib_reports.py
@@ -16,46 +16,46 @@ def read_pdfs():
 def spacy_model(pdfs):
     ###  import labeled_data that has been exported from doccano
 
-    labeled_data = []
-    with open(
-        r"data/raw/new_orleans_pd/training_data/nopd_pib_reports.jsonl",
-        "r",
-    ) as read_file:
-        for line in read_file:
-            data = json.loads(line)
-            labeled_data.append(data)
+    # labeled_data = []
+    # with open(
+    #     r"data/raw/new_orleans_pd/training_data/nopd_pib_reports.jsonl",
+    #     "r",
+    # ) as read_file:
+    #     for line in read_file:
+    #         data = json.loads(line)
+    #         labeled_data.append(data)
 
-    TRAINING_DATA = []
-    for entry in labeled_data:
-        entities = []
-        for e in entry["label"]:
-            entities.append((e[0], e[1], e[2]))
-        spacy_entry = (entry["data"], {"entities": entities})
-        TRAINING_DATA.append(spacy_entry)
+    # TRAINING_DATA = []
+    # for entry in labeled_data:
+    #     entities = []
+    #     for e in entry["label"]:
+    #         entities.append((e[0], e[1], e[2]))
+    #     spacy_entry = (entry["data"], {"entities": entities})
+    #     TRAINING_DATA.append(spacy_entry)
 
     ### train model
 
-    # nlp = spacy.load("data/ner/post/post_officer_history/model/post_officer_history.model")
-    nlp = spacy.blank("en")
-    ner = nlp.create_pipe("ner")
-    nlp.add_pipe("ner")
-    ner.add_label("allegation")
+    nlp = spacy.load(deba.data("raw/new_orleans_pd/model/nopd_pib_reports.model"))
+    # nlp = spacy.blank("en")
+    # ner = nlp.create_pipe("ner")
+    # nlp.add_pipe("ner")
+    # ner.add_label("allegation")
 
-    optimizer = nlp.begin_training()
-    for itn in range(100):
-        random.shuffle(TRAINING_DATA)
-        losses = {}
-        for batch in spacy.util.minibatch(
-            TRAINING_DATA, size=compounding(3.0, 1.5, 1.001)
-        ):
-            for text, annotations in batch:
-                doc = nlp.make_doc(text)
-                example = Example.from_dict(doc, annotations)
-                nlp.update([example], sgd=optimizer, losses=losses, drop=0.4)
-                print(losses)
+    # optimizer = nlp.begin_training()
+    # for itn in range(100):
+    #     random.shuffle(TRAINING_DATA)
+    #     losses = {}
+    #     for batch in spacy.util.minibatch(
+    #         TRAINING_DATA, size=compounding(3.0, 1.5, 1.001)
+    #     ):
+    #         for text, annotations in batch:
+    #             doc = nlp.make_doc(text)
+    #             example = Example.from_dict(doc, annotations)
+    #             nlp.update([example], sgd=optimizer, losses=losses, drop=0.4)
+    #             print(losses)
 
     # save model to disk:
-    nlp.to_disk(deba.data("raw/new_orleans_pd/model/nopd_pib_reports.model"))
+    # nlp.to_disk(deba.data("raw/new_orleans_pd/model/nopd_pib_reports.model"))
 
     entities = []
     for row in pdfs["text"].apply(nlp):

--- a/ner/nopd_pib_reports.py
+++ b/ner/nopd_pib_reports.py
@@ -6,6 +6,7 @@ from spacy.training import Example
 import pandas as pd
 import deba
 import pandas as pd
+from lib.ner import train_spacy_model, apply_spacy_model
 
 
 def read_pdfs():
@@ -13,73 +14,18 @@ def read_pdfs():
     return pdfs
 
 
-def spacy_model(pdfs):
-    ###  import labeled_data that has been exported from doccano
-
-    # labeled_data = []
-    # with open(
-    #     r"data/raw/new_orleans_pd/training_data/nopd_pib_reports.jsonl",
-    #     "r",
-    # ) as read_file:
-    #     for line in read_file:
-    #         data = json.loads(line)
-    #         labeled_data.append(data)
-
-    # TRAINING_DATA = []
-    # for entry in labeled_data:
-    #     entities = []
-    #     for e in entry["label"]:
-    #         entities.append((e[0], e[1], e[2]))
-    #     spacy_entry = (entry["data"], {"entities": entities})
-    #     TRAINING_DATA.append(spacy_entry)
-
-    ### train model
-
-    nlp = spacy.load(deba.data("raw/new_orleans_pd/model/nopd_pib_reports.model"))
-    # nlp = spacy.blank("en")
-    # ner = nlp.create_pipe("ner")
-    # nlp.add_pipe("ner")
-    # ner.add_label("allegation")
-
-    # optimizer = nlp.begin_training()
-    # for itn in range(100):
-    #     random.shuffle(TRAINING_DATA)
-    #     losses = {}
-    #     for batch in spacy.util.minibatch(
-    #         TRAINING_DATA, size=compounding(3.0, 1.5, 1.001)
-    #     ):
-    #         for text, annotations in batch:
-    #             doc = nlp.make_doc(text)
-    #             example = Example.from_dict(doc, annotations)
-    #             nlp.update([example], sgd=optimizer, losses=losses, drop=0.4)
-    #             print(losses)
-
-    # save model to disk:
-    # nlp.to_disk(deba.data("raw/new_orleans_pd/model/nopd_pib_reports.model"))
-
-    entities = []
-    for row in pdfs["text"].apply(nlp):
-        text = [text.text for text in row.ents]
-        labels = [labels.label_ for labels in row.ents]
-        ents = list(zip(labels, text))
-
-        tuples = [i[0] for i in ents]
-        counts = {key: tuples.count(key) for key in [i[0] for i in ents]}
-        for idx, key in enumerate(tuples):
-            if counts.get(key) and counts.get(key) > 1:
-                for num in range(counts[key]):
-                    if key + str(num + 1) not in tuples:
-                        tuples.remove(key)
-                        tuples.insert(idx + num, key + "_" + str(num + 1))
-
-        renamed_ents = dict(zip(tuples, [i[1] for i in ents]))
-        entities.append(renamed_ents)
-
-    ner = pd.DataFrame(entities)
-    return ner
+def training_data():
+    training_data = r"data/raw/new_orleans_pd/training_data/nopd_pib_reports.jsonl"
+    return training_data
 
 
 if __name__ == "__main__":
+    read_training_data = training_data()
     pdfs = read_pdfs()
-    ner = spacy_model(pdfs)
+
+    # train_model = train_spacy_model(pdfs, read_training_data)
+    # train_model = train_model.to_disk(deba.data("raw/new_orleans_pd/model/nopd_pib_reports.model"))
+
+    load_model = spacy.load(deba.data("raw/new_orleans_pd/model/nopd_pib_reports.model"))
+    ner = apply_spacy_model(pdfs, load_model)
     ner.to_csv(deba.data("ner/nopd_pib_reports_2014_2019.csv"), index=False)

--- a/ner/nopd_pib_reports.py
+++ b/ner/nopd_pib_reports.py
@@ -1,16 +1,11 @@
-import json
-import random
 import spacy
-from spacy.util import minibatch, compounding
-from spacy.training import Example
-import pandas as pd
 import deba
 import pandas as pd
 from lib.ner import train_spacy_model, apply_spacy_model
 
 
 def read_pdfs():
-    pdfs = pd.read_csv(deba.data("ocr/nopd_pib_reports_pdfs_2014_2019.csv"))
+    pdfs = pd.read_csv(deba.data("ocr/nopd_pib_reports_pdfs_2014_2020.csv"))
     return pdfs
 
 
@@ -22,10 +17,11 @@ def training_data():
 if __name__ == "__main__":
     read_training_data = training_data()
     pdfs = read_pdfs()
+    # model = train_spacy_model(pdfs, read_training_data)
+    # model = model.to_disk(deba.data("raw/new_orleans_pd/model/nopd_pib_reports.model"))
 
-    # train_model = train_spacy_model(pdfs, read_training_data)
-    # train_model = train_model.to_disk(deba.data("raw/new_orleans_pd/model/nopd_pib_reports.model"))
-
-    load_model = spacy.load(deba.data("raw/new_orleans_pd/model/nopd_pib_reports.model"))
+    load_model = spacy.load(
+        deba.data("raw/new_orleans_pd/model/nopd_pib_reports.model")
+    )
     ner = apply_spacy_model(pdfs, load_model)
-    ner.to_csv(deba.data("ner/nopd_pib_reports_2014_2019.csv"), index=False)
+    ner.to_csv(deba.data("ner/nopd_pib_reports_2014_2020.csv"), index=False)

--- a/ner/nopd_pib_reports.py
+++ b/ner/nopd_pib_reports.py
@@ -1,0 +1,85 @@
+import json
+import random
+import spacy
+from spacy.util import minibatch, compounding
+from spacy.training import Example
+import pandas as pd
+import deba
+import pandas as pd
+
+
+def read_pdfs():
+    pdfs = pd.read_csv(deba.data("ocr/nopd_pib_reports_pdfs.csv"))
+    return pdfs
+
+
+def spacy_model(pdfs):
+    ###  import labeled_data that has been exported from doccano
+
+    labeled_data = []
+    with open(
+        r"data/raw/new_orleans_pd/training_data/nopd_pib_reports.jsonl",
+        "r",
+    ) as read_file:
+        for line in read_file:
+            data = json.loads(line)
+            labeled_data.append(data)
+
+    TRAINING_DATA = []
+    for entry in labeled_data:
+        entities = []
+        for e in entry["label"]:
+            entities.append((e[0], e[1], e[2]))
+        spacy_entry = (entry["data"], {"entities": entities})
+        TRAINING_DATA.append(spacy_entry)
+
+    ### train model
+
+    # nlp = spacy.load("data/ner/post/post_officer_history/model/post_officer_history.model")
+    nlp = spacy.blank("en")
+    ner = nlp.create_pipe("ner")
+    nlp.add_pipe("ner")
+    ner.add_label("allegation")
+
+    optimizer = nlp.begin_training()
+    for itn in range(100):
+        random.shuffle(TRAINING_DATA)
+        losses = {}
+        for batch in spacy.util.minibatch(
+            TRAINING_DATA, size=compounding(3.0, 1.5, 1.001)
+        ):
+            for text, annotations in batch:
+                doc = nlp.make_doc(text)
+                example = Example.from_dict(doc, annotations)
+                nlp.update([example], sgd=optimizer, losses=losses, drop=0.4)
+                print(losses)
+
+    # save model to disk:
+    nlp.to_disk(deba.data("raw/new_orleans_pd/model/nopd_pib_reports.model"))
+
+    entities = []
+    for row in pdfs["text"].apply(nlp):
+        text = [text.text for text in row.ents]
+        labels = [labels.label_ for labels in row.ents]
+        ents = list(zip(labels, text))
+
+        tuples = [i[0] for i in ents]
+        counts = {key: tuples.count(key) for key in [i[0] for i in ents]}
+        for idx, key in enumerate(tuples):
+            if counts.get(key) and counts.get(key) > 1:
+                for num in range(counts[key]):
+                    if key + str(num + 1) not in tuples:
+                        tuples.remove(key)
+                        tuples.insert(idx + num, key + "_" + str(num + 1))
+
+        renamed_ents = dict(zip(tuples, [i[1] for i in ents]))
+        entities.append(renamed_ents)
+
+    ner = pd.DataFrame(entities)
+    return ner
+
+
+if __name__ == "__main__":
+    pdfs = read_pdfs()
+    ner = spacy_model(pdfs)
+    ner.to_csv(deba.data("ner/nopd_pib_reports_2014_2019.csv"), index=False)

--- a/ner/nopd_pib_reports.py
+++ b/ner/nopd_pib_reports.py
@@ -10,7 +10,7 @@ from lib.ner import train_spacy_model, apply_spacy_model
 
 
 def read_pdfs():
-    pdfs = pd.read_csv(deba.data("ocr/nopd_pib_reports_pdfs.csv"))
+    pdfs = pd.read_csv(deba.data("ocr/nopd_pib_reports_pdfs_2014_2019.csv"))
     return pdfs
 
 

--- a/ocr/nopd_pib_reports.py
+++ b/ocr/nopd_pib_reports.py
@@ -1,0 +1,22 @@
+import deba
+import pandas as pd
+from lib.dvc import real_dir_path
+from lib.ocr import process_pdf
+
+
+def only_pdf(df: pd.DataFrame) -> pd.DataFrame:
+    return df.loc[df.filetype == "pdf"].reset_index(drop=True)
+
+
+def process_all_pdfs() -> pd.DataFrame:
+    dir_name = real_dir_path("raw_nopd_pib_reports.dvc")
+    return (
+        pd.read_csv(deba.data("meta/nopd_pib_reports_files.csv"))
+        .pipe(only_pdf)
+        .pipe(process_pdf, dir_name)
+    )
+
+
+if __name__ == "__main__":
+    df = process_all_pdfs()
+    df.to_csv(deba.data("ocr/nopd_pib_reports_pdfs_2014_2019.csv"), index=False)

--- a/ocr/nopd_pib_reports.py
+++ b/ocr/nopd_pib_reports.py
@@ -9,14 +9,14 @@ def only_pdf(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def process_all_pdfs() -> pd.DataFrame:
-    dir_name = real_dir_path("raw_post_officer_history_reports.dvc")
+    dir_name = real_dir_path("raw_nopd_pib_reports.dvc")
     return (
-        pd.read_csv(deba.data("meta/nopd_pib_report_files_2014_2019.csv"))
+        pd.read_csv(deba.data("meta/nopd_pib_report_files_2014_2020.csv"))
         .pipe(only_pdf)
-        .pipe(process_pdf, dir_name)
+        .pipe(process_pdf, dir_name, output_images_to_tempdir=False)
     )
 
 
 if __name__ == "__main__":
     df = process_all_pdfs()
-    df.to_csv(deba.data("ocr/nopd_pib_reports_pdfs_2014_2019.csv"), index=False)
+    df.to_csv(deba.data("ocr/nopd_pib_reports_pdfs_2014_2020.csv"), index=False)

--- a/ocr/nopd_pib_reports.py
+++ b/ocr/nopd_pib_reports.py
@@ -11,7 +11,7 @@ def only_pdf(df: pd.DataFrame) -> pd.DataFrame:
 def process_all_pdfs() -> pd.DataFrame:
     dir_name = real_dir_path("raw_nopd_pib_reports.dvc")
     return (
-        pd.read_csv(deba.data("meta/nopd_pib_reports_files_2014_2019.csv"))
+        pd.read_csv(deba.data("meta/nopd_pib_report_files_2014_2019.csv"))
         .pipe(only_pdf)
         .pipe(process_pdf, dir_name)
     )

--- a/ocr/nopd_pib_reports.py
+++ b/ocr/nopd_pib_reports.py
@@ -9,7 +9,7 @@ def only_pdf(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def process_all_pdfs() -> pd.DataFrame:
-    dir_name = real_dir_path("raw_nopd_pib_reports.dvc")
+    dir_name = real_dir_path("raw_post_officer_history_reports.dvc")
     return (
         pd.read_csv(deba.data("meta/nopd_pib_report_files_2014_2019.csv"))
         .pipe(only_pdf)

--- a/ocr/nopd_pib_reports.py
+++ b/ocr/nopd_pib_reports.py
@@ -11,7 +11,7 @@ def only_pdf(df: pd.DataFrame) -> pd.DataFrame:
 def process_all_pdfs() -> pd.DataFrame:
     dir_name = real_dir_path("raw_nopd_pib_reports.dvc")
     return (
-        pd.read_csv(deba.data("meta/nopd_pib_reports_files.csv"))
+        pd.read_csv(deba.data("meta/nopd_pib_reports_files_2014_2019.csv"))
         .pipe(only_pdf)
         .pipe(process_pdf, dir_name)
     )

--- a/ocr_cache.dvc
+++ b/ocr_cache.dvc
@@ -1,6 +1,6 @@
 wdir: data
 outs:
-- md5: 224852edfa4ee24661a6677e95e3f513.dir
-  size: 20484955
-  nfiles: 1589
+- md5: 4f4a40c770113bcc02dc17a76b150bf7.dir
+  size: 21934446
+  nfiles: 1595
   path: ocr_cache

--- a/ocr_cache.dvc
+++ b/ocr_cache.dvc
@@ -1,6 +1,6 @@
 wdir: data
 outs:
-- md5: 4f4a40c770113bcc02dc17a76b150bf7.dir
-  size: 21934446
-  nfiles: 1595
+- md5: 7121e7d8a6b6b9afbcea070de25c376f.dir
+  size: 22176655
+  nfiles: 1596
   path: ocr_cache

--- a/raw_nopd_pib_reports.dvc
+++ b/raw_nopd_pib_reports.dvc
@@ -1,0 +1,6 @@
+wdir: data
+outs:
+- md5: 97ddcf8bb19616b6ebaaf2255affe3ac.dir
+  size: 3637499
+  nfiles: 6
+  path: raw_nopd_pib_reports

--- a/raw_nopd_pib_reports.dvc
+++ b/raw_nopd_pib_reports.dvc
@@ -1,6 +1,6 @@
 wdir: data
 outs:
-- md5: 97ddcf8bb19616b6ebaaf2255affe3ac.dir
-  size: 3637499
-  nfiles: 6
+- md5: 1f2eb9d1becfc20c831c7711a6d322c9.dir
+  size: 4153118
+  nfiles: 7
   path: raw_nopd_pib_reports

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ flake8==4.0.1
 black==21.12b0
 deba==0.1.6
 dvc[gs]==2.10.1
+pdf2image==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ deba==0.1.6
 dvc[gs]==2.10.1
 pdf2image==1.16.0
 pytesseract==0.3.9
+spacy==3.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ black==21.12b0
 deba==0.1.6
 dvc[gs]==2.10.1
 pdf2image==1.16.0
+pytesseract==0.3.9


### PR DESCRIPTION
@pckhoi Q for you. 

These PIB annual reports, from 2014-2019, contain a `tracking_id` which allows for them to be merged with our NOPD data. Because some `tracking_id`'s can be associated with 2 or more officers, the only way, I think, of matching them efficiently is to drop all of the `tracking_id`'s associated with 2 or more officers and subsequently match those `tracking_id`'s with our current NOPD data. 

Atm, our NOPD data is split into two scripts: `clean/cprr_new_orleans_pd_1931_2020.csv` (contains `tracking_id` and `officer_primary_key`) and `clean/pprr_new_orleans_ipm_iapro_1946_2018.csv` (contains `first_name`, `last_name` and `officer_primary_key`). 

What do you think is the best way to match?  