### PR TITLE
Upgrade deba to 0.1.6

### DIFF
--- a/deba.yaml
+++ b/deba.yaml
@@ -2,6 +2,8 @@ dataDir: data
 patterns:
   prerequisites:
     - pd.read_csv(deba.data(r'.+\.csv'))
+  references:
+    - files_meta_frame(r'.+\.dvc')
   targets:
     - "`*`.to_csv(deba.data(r'.+\\.csv'))"
 stages:
@@ -25,16 +27,3 @@ targets:
   - fuse/stop_and_search.csv
   - fuse/appeals.csv
   - fuse/event.csv
-overrides:
-  - target:
-      - meta/minutes_files.csv
-    prerequisites:
-      - $(DEBA_MD5_DIR)/meta/minutes.py.md5
-      - $(DEBA_MD5_DIR)/raw_minutes.dvc.md5
-    recipe: "$(call deba_execute,meta/minutes.py)"
-  - target:
-      - meta/post_officer_history_reports_files.csv
-    prerequisites:
-      - $(DEBA_MD5_DIR)/meta/post_officer_history_reports.py.md5
-      - $(DEBA_MD5_DIR)/raw_post_officer_history_reports.dvc.md5 
-    recipe: "$(call deba_execute,meta/post_officer_history_reports.py)"

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ requests==2.26.0
 wrgl==0.11.6
 flake8==4.0.1
 black==21.12b0
-deba==0.1.5
+deba==0.1.6
 dvc[gs]==2.10.1


### PR DESCRIPTION
Deba version 0.1.6 introduces `references` pattern which are like `prerequisites` except they are assumed to be version controlled by Git and not contained in `dataDir`.