### PR TITLE
Add an OCR job queue

### DIFF
--- a/k8s-ocr-jobqueue/README.md
+++ b/k8s-ocr-jobqueue/README.md
@@ -1,0 +1,34 @@
+# Kubernetes OCR job queue
+
+## Install/update
+
+Check out [pckhoi/k8s-ocr-jobqueue](https://github.com/pckhoi/k8s-ocr-jobqueue)
+
+## Queue PDF for OCR
+
+```bash
+scripts/queue_pdf_for_ocr.py PDF_DIRECTORY [PDF_DIRECTORY...]
+```
+
+## Check job status
+
+```bash
+# see pod status
+kubectl get pods -n k8s-ocr-jobqueue -w
+# see job log
+kubectl logs -n k8s-ocr-jobqueue -f -l job-name=doctr
+```
+
+## Download OCR results
+
+```python
+from lib.ocr import fetch_ocr_text
+...
+fetch_ocr_text(files_prefix)
+```
+
+## Uninstall job queue
+
+```bash
+scripts/uninstall_k8s_ocr_jobqueue.sh
+```

--- a/k8s-ocr-jobqueue/job.yml
+++ b/k8s-ocr-jobqueue/job.yml
@@ -1,0 +1,29 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: doctr
+spec:
+  template:
+    spec:
+      containers:
+        - name: doctr
+          image: doctr
+          env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /etc/service_account/key.json
+          envFrom:
+            - configMapRef:
+                name: doctr-config
+          volumeMounts:
+            - name: service-account-key
+              mountPath: "/etc/service_account"
+              readOnly: true
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: "1"
+      volumes:
+        - name: service-account-key
+          secret:
+            secretName: service-account-key
+      restartPolicy: OnFailure

--- a/k8s-ocr-jobqueue/kustomization.yml
+++ b/k8s-ocr-jobqueue/kustomization.yml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: k8s-ocr-jobqueue
+resources:
+  - job.yml
+commonLabels:
+  app.kubernetes.io/part-of: k8s-ocr-jobqueue
+images:
+  - name: doctr
+    newName: gcr.io/excellent-zoo-300106/doctr
+    newTag: 89c0f9f6ae2c
+configMapGenerator:
+  - literals:
+      - SOURCE_BUCKET=k8s-ocr-jobqueue-pdfs
+      - SINK_BUCKET=k8s-ocr-jobqueue-results
+    name: doctr-config

--- a/notebooks/ocr.ipynb
+++ b/notebooks/ocr.ipynb
@@ -1,0 +1,260 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys; sys.path.insert(0, '..')\n",
+    "from subprocess import CalledProcessError\n",
+    "\n",
+    "import pandas as pd\n",
+    "from lib.ocr import fetch_ocr_results, fetch_ocr_text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                                                                   \r"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>filepath</th>\n",
+       "      <th>pageno</th>\n",
+       "      <th>text</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>53</th>\n",
+       "      <td>raw_minutes/addis/atc/120518MeetingMinutes.pdf</td>\n",
+       "      <td>1</td>\n",
+       "      <td>TOWN OF ADDIS MINUTES\\nREGULAR MEETING-DECEMBE...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>55</th>\n",
+       "      <td>raw_minutes/addis/atc/120518MeetingMinutes.pdf</td>\n",
+       "      <td>2</td>\n",
+       "      <td>Town of Addis Minutes\\nRegular Meeting - Decem...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>54</th>\n",
+       "      <td>raw_minutes/addis/atc/120518MeetingMinutes.pdf</td>\n",
+       "      <td>3</td>\n",
+       "      <td>Town of Addis Minutes\\nRegular Meeting- Decemb...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>56</th>\n",
+       "      <td>raw_minutes/addis/atc/120518MeetingMinutes.pdf</td>\n",
+       "      <td>4</td>\n",
+       "      <td>ANY OTHER BUSINESS\\nADJOURN\\nMayor Toups prese...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>39</th>\n",
+       "      <td>raw_minutes/addis/atc/AI4-MINUTES-2020-05-06.pdf</td>\n",
+       "      <td>1</td>\n",
+       "      <td>TOWN OF ADDIS MINUTES\\nMay 6, 2020 - Regular M...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2035</th>\n",
+       "      <td>raw_minutes/kenner/fpcsb/CS Board Mtg 2013_Red...</td>\n",
+       "      <td>82</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2034</th>\n",
+       "      <td>raw_minutes/kenner/fpcsb/CS Board Mtg 2013_Red...</td>\n",
+       "      <td>83</td>\n",
+       "      <td>CITY OF KENNER, LOUISIANA\\nCIVIL SERVICE BOARD...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021</th>\n",
+       "      <td>raw_minutes/kenner/fpcsb/CS Board Mtg 2013_Red...</td>\n",
+       "      <td>84</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2012</th>\n",
+       "      <td>raw_minutes/kenner/fpcsb/CS Board Mtg 2013_Red...</td>\n",
+       "      <td>85</td>\n",
+       "      <td>EXHIBIT A\\nCITY OF KENNER, LOUISIANA\\nCIVIL SE...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2091</th>\n",
+       "      <td>raw_minutes/kenner/fpcsb/CS Board Mtg 2013_Red...</td>\n",
+       "      <td>86</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>3265 rows × 3 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                               filepath  pageno  \\\n",
+       "53       raw_minutes/addis/atc/120518MeetingMinutes.pdf       1   \n",
+       "55       raw_minutes/addis/atc/120518MeetingMinutes.pdf       2   \n",
+       "54       raw_minutes/addis/atc/120518MeetingMinutes.pdf       3   \n",
+       "56       raw_minutes/addis/atc/120518MeetingMinutes.pdf       4   \n",
+       "39     raw_minutes/addis/atc/AI4-MINUTES-2020-05-06.pdf       1   \n",
+       "...                                                 ...     ...   \n",
+       "2035  raw_minutes/kenner/fpcsb/CS Board Mtg 2013_Red...      82   \n",
+       "2034  raw_minutes/kenner/fpcsb/CS Board Mtg 2013_Red...      83   \n",
+       "2021  raw_minutes/kenner/fpcsb/CS Board Mtg 2013_Red...      84   \n",
+       "2012  raw_minutes/kenner/fpcsb/CS Board Mtg 2013_Red...      85   \n",
+       "2091  raw_minutes/kenner/fpcsb/CS Board Mtg 2013_Red...      86   \n",
+       "\n",
+       "                                                   text  \n",
+       "53    TOWN OF ADDIS MINUTES\\nREGULAR MEETING-DECEMBE...  \n",
+       "55    Town of Addis Minutes\\nRegular Meeting - Decem...  \n",
+       "54    Town of Addis Minutes\\nRegular Meeting- Decemb...  \n",
+       "56    ANY OTHER BUSINESS\\nADJOURN\\nMayor Toups prese...  \n",
+       "39    TOWN OF ADDIS MINUTES\\nMay 6, 2020 - Regular M...  \n",
+       "...                                                 ...  \n",
+       "2035                                                     \n",
+       "2034  CITY OF KENNER, LOUISIANA\\nCIVIL SERVICE BOARD...  \n",
+       "2021                                                     \n",
+       "2012  EXHIBIT A\\nCITY OF KENNER, LOUISIANA\\nCIVIL SE...  \n",
+       "2091                                                     \n",
+       "\n",
+       "[3265 rows x 3 columns]"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = fetch_ocr_text('raw_minutes')\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TOWN OF ADDIS MINUTES\n",
+      "REGULAR MEETING-DECEMBER 5, 2018\n",
+      "The regular meeting of the Mayor and Town Council for the Town of Addis was called to order by Mayor Toups at 6:00\n",
+      "p.m. on Wednesday, December 5, 2018 and held at the Addis Municipal Building located at 7818 Highway 1 South. Mayor\n",
+      "Toups asked for a moment of silence in memory of George H. W. Bush. The Pledge to the Flag was led by Judge Elizabeth\n",
+      "Engolio.\n",
+      "ROLLCALL\n",
+      "Absent: None\n",
+      "MINUTES\n",
+      "Present: Mayor David Toups; Councilors Wilson Cazes, Tate Acosta, Kevin LeBlanc, Rusty Parrish, Rhonda Kelley\n",
+      "The minutes of the November 7, 2018 meeting were reviewed and approved on a motion made by Councilor\n",
+      "seconded by Councilor Kelley and adopted unanimously by those present.\n",
+      "ADDITIONS TO AGENDA\n",
+      "At the request of Mayor Toups, a motion was made by Councilor Kelley, seconded by Councilor LeBlanc to add an update\n",
+      "by Tipton Associates to the meetingsagenda. The motion was adopted unanimously.\n",
+      "PUBLIC COMMENTS\n",
+      "None\n",
+      "CORRESPONDENCE\n",
+      "None\n",
+      "JEREMYLACOMBE, CANDIDATE FOR STATE REPRESENTATIVE\n",
+      "Mr. LaCombe thanked the Council for allowing him to attend the meeting. He advised that he is running for\n",
+      "Representative and asked for support from those present. Mr. LaCombe advised that he is an attorney in New Roads\n",
+      "has practiced law for 15 years. He further advised the various types of cases he has handled and has previously worke\n",
+      "governmental venues. Mayor Toups thanked Mr. LaCombe for his attendance and remark, and wished him luck in the\n",
+      "upcoming February 23rd election.\n",
+      "TIPTON ASSOCIATES\n",
+      "A representative from Tipton Associates addressed the Council concerning the proposed renovations to the Town Hall\n",
+      "building. Mayor Toups advised that he wants the Building Committee, Chief of Police, and Department Heads to hold a\n",
+      "meeting to thoroughly assess the needs of the Town's activities in relation to the proposed estimates given by Tipton.\n",
+      "Acadian Crossing/Bernhardt Force Main - Recommendation of Award - Bids on this project were received by November 14,\n",
+      "2018. They were reviewed by Mr. Boudreaux who recommends that the Town accept the low bid of LaGreca Services, Inc.\n",
+      "of Schriever, LA, in the amount of $597,745.40. A motion to accept the recommendation of Mr. Boudreaux and approve\n",
+      "the low bid submitted by LaGreca Services, Inc. of Schriever, LA in the amount of $597,745.40 contingent upon DEQ\n",
+      "approval was made by Councilor Acosta; seconded by Councilor Parrish and adopted unanimously. Mr. Boudreaux\n",
+      "Bernhardt Pump Station Upgrade - Change Order NO. 2 - After review and discussion, a motion to approve Change Order\n",
+      "NO. 2, in the amount of $5,137.42 for the rehabilitation of the \"ailing\" pumps on the Bernhardt Pump Station made by\n",
+      "OSCAR BOUDREAUX\n",
+      "advised that work would begin after LDEQ's approval of the contract documents.\n",
+      "Councilor Acosta; seconded by Councilor Kelley and adopted unanimously.\n",
+      "Project Updates\n",
+      "i.\n",
+      "YMCA Force Main = EES Project #1627 - Contractor is waiting on the Mississippi river to drop. Work is\n",
+      "presently on hold.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(df.iloc[0, 2])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.9.13 ('base')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "2c95fe248860bd69136fd5934ca42b0656bc63db691883986ab38f5f0d896be5"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.18.5
-pandas==1.2.4
+pandas==1.4.2
 python-Levenshtein==0.12.0
 Unidecode==1.1.2
 datamatch==0.1.15
@@ -19,3 +19,4 @@ dvc[gs]==2.10.1
 pdf2image==1.16.0
 pytesseract==0.3.9
 spacy==3.3.1
+pypdfium2==2.11.0

--- a/scripts/queue_pdf_for_ocr.py
+++ b/scripts/queue_pdf_for_ocr.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+import os
+import argparse
+import tempfile
+import subprocess
+import json
+
+from tqdm import tqdm
+import pypdfium2 as pdfium
+
+
+SOURCE_BUCKET = "k8s-ocr-jobqueue-pdfs"
+KUSTOMIZE_DIR = "k8s-ocr-jobqueue"
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Enqueue PDF files for OCR processing."
+    )
+    parser.add_argument(
+        "paths",
+        metavar="PATH",
+        type=str,
+        nargs="+",
+        help="a path that contain PDF files to be enqueued. Files that already exist in the queue will be ignored.",
+    )
+    args = parser.parse_args()
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        paths = args.paths
+        pos = 0
+        if len(paths) > 1:
+            paths = tqdm(paths, desc="pdf paths", position=0, leave=False)
+            pos = 1
+        for path in paths:
+            path = path.rstrip("/")
+            head, _ = os.path.split(path)
+            for root, _, files in tqdm(
+                list(os.walk(path)), desc=path, position=pos, leave=False
+            ):
+                relroot = os.path.relpath(root, head)
+                for file in tqdm(files, desc=root, position=pos + 1, leave=False):
+                    if not file.endswith(".pdf"):
+                        continue
+                    filepath = os.path.join(root, file)
+                    with pdfium.PdfDocument(filepath) as pdf:
+                        for ind, img in enumerate(
+                            tqdm(
+                                pdf.render_topil(scale=2),
+                                desc="splitting %s" % json.dumps(file),
+                                position=pos + 2,
+                                leave=False,
+                            )
+                        ):
+                            filepath = os.path.abspath(
+                                os.path.join(
+                                    tmpdirname, relroot, file, "%03d.png" % (ind + 1,)
+                                )
+                            )
+                            os.makedirs(os.path.dirname(filepath), exist_ok=True)
+                            img.save(filepath, "PNG")
+        subprocess.run(
+            [
+                "gsutil",
+                "-m",
+                "rsync",
+                "-c",
+                "-i",
+                "-J",
+                "-r",
+                tmpdirname,
+                "gs://%s" % (SOURCE_BUCKET,),
+            ],
+            check=True,
+        )
+    subprocess.run(
+        [
+            "bash",
+            "-c",
+            "kustomize build %s | kubectl apply -f -" % KUSTOMIZE_DIR,
+        ],
+    )

--- a/scripts/uninstall_k8s_ocr_jobqueue.sh
+++ b/scripts/uninstall_k8s_ocr_jobqueue.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+trap cleanup SIGINT SIGTERM ERR EXIT
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+declare -a executables=("gcloud" "gsutil" "kubectl")
+
+project_id=excellent-zoo-300106
+input_bucket=k8s-ocr-jobqueue-pdfs
+output_bucket=k8s-ocr-jobqueue-results
+service_account=k8s-ocr-jobqueue
+namespace=k8s-ocr-jobqueue
+
+usage() {
+  cat <<EOF
+Usage: $(basename "${BASH_SOURCE[0]}") [-h] [-v] [-b]
+Uninstall OCR job queue
+Available options:
+-h, --help              Print this help and exit
+-v, --verbose           Print script debug info
+-b, --buckets           Remove buckets and all of their data.
+EOF
+  exit
+}
+
+cleanup() {
+  trap - SIGINT SIGTERM ERR EXIT
+  # script cleanup here
+}
+
+setup_colors() {
+  if [[ -t 2 ]] && [[ -z "${NO_COLOR-}" ]] && [[ "${TERM-}" != "dumb" ]]; then
+NOFORMAT='\033[0m' RED='\033[0;31m' GREEN='\033[0;32m' ORANGE='\033[0;33m' BLUE='\033[0;34m' PURPLE='\033[0;35m' CYAN='\033[0;36m' YELLOW='\033[1;33m'
+  else
+NOFORMAT='' RED='' GREEN='' ORANGE='' BLUE='' PURPLE='' CYAN='' YELLOW=''
+  fi
+}
+
+msg() {
+  echo >&2 -e "${1-}"
+}
+
+die() {
+  local msg=$1
+  local code=${2:-1} # default exit status 1
+  msg "Error: $msg"
+  exit "$code"
+}
+
+check_executables() {
+  for cmd in "${executables[@]}"
+  do
+    command -v $cmd >/dev/null 2>&1 || die "$cmd could not be found"
+  done
+}
+
+parse_params() {
+  # default values of variables set from params
+  buckets=0
+
+  while :; do
+case "${1-}" in
+-h | --help) usage ;;
+-v | --verbose) set -x ;;
+--no-color) NO_COLOR=1 ;;
+-b | --buckets) buckets=1 ;;
+-?*) die "Unknown option: " ;;
+*) break ;;
+esac
+shift
+  done
+
+  return 0
+}
+
+uninstall() {
+    kubectl delete namespace $namespace --ignore-not-found=true
+    gcloud iam service-accounts delete --quiet \
+        $service_account@$project_id.iam.gserviceaccount.com
+    [[ ${buckets} -eq 1 ]] \
+        && gsutil rm -r gs://$input_bucket \
+        && gsutil rm -r gs://$output_bucket
+}
+
+parse_params "$@"
+check_executables
+setup_colors
+
+uninstall


### PR DESCRIPTION
This OCR job queue operates by first filling a source bucket (`gs://k8s-ocr-jobqueue-pdfs`) with images extracted from PDF files. It then schedule a job on Kubernetes to process all images and save results to a sink bucket (`gs://k8s-ocr-jobqueue-results`). I have provided scripts to help operate.

This job queue can be installed on any project by following guidance here: [pckhoi/k8s-ocr-jobqueue](https://github.com/pckhoi/k8s-ocr-jobqueue).

Please read [k8s-ocr-jobqueue/README.md](https://github.com/ppact/processing/blob/2cd09cb/k8s-ocr-jobqueue/README.md) for usage.